### PR TITLE
Fixed the title to prevent it from overlapping with the logo

### DIFF
--- a/yacysearch/about.html
+++ b/yacysearch/about.html
@@ -68,7 +68,7 @@ open about:config and set security.fileuri.strict_origin_policy to ‘false.’
         <a id="homepage" class="navbar-brand" href="http://susper.com" style="position:absolute;top:-6px;display:inline;white-space:nowrap;">
           <img id="logo" class="yacylogo" src="../images/susper.svg" alt="YaCy" style="height:auto; width:auto; max-width:200px; max-height:32px;vertical-align:middle">
         </a>
-        <span id="greeting" style="position:absolute;top:12px;left:80px;display:inline;white-space:nowrap;font-size:2em;">About This Search Portal</span>
+        <span id="greeting" style="position:relative;top:12px;left:70%;display:inline;white-space:nowrap;font-size:2em;">About This Search Portal</span>
       </div>
       <div class="navbar-collapse collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/yacysearch/usage.html
+++ b/yacysearch/usage.html
@@ -68,7 +68,7 @@ open about:config and set security.fileuri.strict_origin_policy to ‘false.’
         <a id="homepage" class="navbar-brand" href="http://susper.com" style="position:absolute;top:-6px;display:inline;white-space:nowrap;">
           <img id="logo" class="yacylogo" src="../images/susper.svg" alt="YaCy" style="height:auto; width:auto; max-width:200px; max-height:32px;vertical-align:middle">
         </a>
-        <span id="greeting" style="position:absolute;top:12px;left:80px;display:inline;white-space:nowrap;font-size:2em;">Usage of Search Templates</span>
+        <span id="greeting" style="position:absolute;top:12px;left:35%;display:inline;white-space:nowrap;font-size:2em;">Usage of Search Templates</span>
       </div>
       <div class="navbar-collapse collapse">
         <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
I found this issue with the design of the about page while hacking through susper, and thought of fixing it. So, I changed absolute pixel positioning to percentage relative positioning. [](http://susper.com/yacysearch/about.html) is how the page looked originally, I have attached a screenshot of how it looks now.Hope it works for you.
![image](https://cloud.githubusercontent.com/assets/20185076/21080816/eec45962-bfde-11e6-83b7-5d432f4c4815.png)



