### PR TITLE
language exceptions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/assets/* linguist-vendored


### PR DESCRIPTION
present language of the repository is being shown as css, since assets folder has a lot vendor files , which are being treated as repositories primary files by liguist.  hence all files in assets folder are made vendored to change the primary language to TypeScript .