### PR TITLE
Fixes #103 Search button properly aligned

### DIFF
--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -56,4 +56,19 @@
   #nav-input{
     width: 80vw;
   }
+  .align-search-btn{
+    left: -9%;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .align-search-btn{
+    left: -6%;
+  }
+}
+
+@media screen and (max-width: 360px) {
+  .align-search-btn{
+    left: -5%;
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -32,6 +32,7 @@
     var isFirefox = typeof InstallTrigger !== 'undefined';
     if(isFirefox === false){
       $("#set-susper-default").remove();
+      $(".input-group-btn").addClass("align-search-btn");
     }
     if(window.external && window.external.IsSearchProviderInstalled){
       var isInstalled = window.external.IsSearchProviderInstalled("http://susper.com");


### PR DESCRIPTION
The problem with the search button being not aligned with the search input field on small screens for browsers other than Firefox is fixed. There is no break between the two now.
Screenshot:-
![screenshot from 2017-03-06 03 43 50](https://cloud.githubusercontent.com/assets/15105247/23591955/217e3602-021f-11e7-882c-006f47c7607b.png)
