### PR TITLE
fixed merge conflicts from before

### DIFF
--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,13 +1,20 @@
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <nav class="navbar navbar-fixed-top navbar-default">
         <div class="container-fluid">
-            <div class="navbar-header">
-                <a href="/">
+            <div class="navbar-header" id="navcontainer">
+              <ul>
+                <li>
+                  <a href="/">
                     <img class="navbar-brand" src="assets/images/susper.svg">
-                </a>
+                  </a>
+                </li>
+                <li id="navbar-search">
+                    <app-search-bar></app-search-bar>
+                </li>
+              </ul>
             </div>
-            <div class="navbar-collapse collapse">
-                <app-search-bar></app-search-bar>
+
+            <div class="navbar-collapse collapse" style="display:none" id="side-menu">
                 <ul class="nav navbar-nav navbar-right">
                     <li class="dropdown">
                         <a href="#" data-toggle="dropdown" class="dropdown-toggle" data-proofer-ignore><i class="fa fa-bars" aria-hidden="true" style="font-size: 2em"></i></a>
@@ -58,6 +65,7 @@
             </div>
         </div>
     </nav>
+
     <script>
       $(document).ready(function(){
         var isFirefox = typeof InstallTrigger !== 'undefined';

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -1,28 +1,33 @@
 <app-navbar></app-navbar>
-    <div class="container">
+    <!-- <div class="container"> -->
         <!-- Start ignoring BootLintBear -->
         <div class="row">
-            <div class="col-md-offset-1">
+            <!-- <div class="col-md-offset-1"> -->
                 <!-- Stop ignoring BootLintBear -->
+            <!-- </div> -->
+            <div class="container-fluid" id="search-options-field">
+              <ul type="none" id="search-options">
+                  <li [class.active_view]="Display('all')" (click)="docClick()">All</li>
+                  <li [class.active_view]="Display('images')" (click)="imageClick()">Images</li>
+                  <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
+                  <li class="dropdown">
+                    <a href="#" id="tools" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                        Tools
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="tools" id="tool-dropdown">
+                      <li (click)="filterByContext()">Context Ranking</li>
+                      <li (click)="filterByDate()">Sort by Date</li>
+                      <li data-toggle="modal" data-target="#myModal" (click)="advancedsearch()">Advanced Search</li>
+                    </ul>
+                  </li>
+              </ul>
+              <!-- <div class="collapse" id="search-tools">
+                  <button class="btn btn-default" (click)="filterByContext()" type="button"> Context Ranking</button>
+                  <button class="btn btn-default" (click)="filterByDate()" type="button"> Sort by Date</button>
+                  <button class="btn btn-default" data-toggle="modal" data-target="#myModal" (click)="advancedsearch()" type="button"> Advanced Search</button>
+              </div> -->
             </div>
-            <div class="col-md-11">
-                <div class="btn-group" id="search-options">
-                    <button type="button" class="btn btn-default" [class.active_view]="Display('all')" (click)="docClick()">
-                        All
-                    </button>
-                    <button type="button" class="btn btn-default" [class.active_view]="Display('images')" (click)="imageClick()">Images</button>
-                    <button type="button" class="btn btn-default" [class.active_view]="Display('videos')" (click)="videoClick()">Videos</button>
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-default" id="tools" data-toggle="collapse" data-target="#search-tools">
-                            Tools <span class="caret"></span></button>
-                    </div>
-                </div>
-                <div class="collapse" id="search-tools">
-                    <button class="btn btn-default" (click)="filterByContext()" type="button"> Context Ranking</button>
-                    <button class="btn btn-default" (click)="filterByDate()" type="button"> Sort by Date</button>
-                    <button class="btn btn-default" data-toggle="modal" data-target="#myModal" (click)="advancedsearch()" type="button"> Advanced Search</button>
-                </div>
-                <hr>
+            <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
                 <div class="container-fluid" id="progress-bar">
                     {{message}}
                 </div>
@@ -46,7 +51,7 @@
                 </div>
                 <div class="video-result" *ngIf="Display('videos')">
                     <div *ngFor="let item of items$|async" class="result">
-                       <div class="title">
+                        <div class="title">
                             <a href="{{item.path}}">{{item.title}}</a>
                         </div>
                         <div class="link">
@@ -55,7 +60,6 @@
                     </div>
                 </div>
                 <br>
-                <div class="clean"></div>
                 <div class="pagination-property">
                     <nav aria-label="Page navigation">
                         <ul class="pagination" id="pag-bar">
@@ -73,10 +77,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    <!-- </div> -->
     <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
         <app-advancedsearch></app-advancedsearch>
     </div>
-
-
-

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -1,83 +1,72 @@
 <app-navbar></app-navbar>
-    <!-- <div class="container"> -->
-        <!-- Start ignoring BootLintBear -->
-        <div class="row">
-            <!-- <div class="col-md-offset-1"> -->
-                <!-- Stop ignoring BootLintBear -->
-            <!-- </div> -->
-            <div class="container-fluid" id="search-options-field">
-              <ul type="none" id="search-options">
-                  <li [class.active_view]="Display('all')" (click)="docClick()">All</li>
-                  <li [class.active_view]="Display('images')" (click)="imageClick()">Images</li>
-                  <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
-                  <li class="dropdown">
-                    <a href="#" id="tools" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                        Tools
-                    </a>
-                    <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="tools" id="tool-dropdown">
-                      <li (click)="filterByContext()">Context Ranking</li>
-                      <li (click)="filterByDate()">Sort by Date</li>
-                      <li data-toggle="modal" data-target="#myModal" (click)="advancedsearch()">Advanced Search</li>
-                    </ul>
-                  </li>
-              </ul>
-              <!-- <div class="collapse" id="search-tools">
-                  <button class="btn btn-default" (click)="filterByContext()" type="button"> Context Ranking</button>
-                  <button class="btn btn-default" (click)="filterByDate()" type="button"> Sort by Date</button>
-                  <button class="btn btn-default" data-toggle="modal" data-target="#myModal" (click)="advancedsearch()" type="button"> Advanced Search</button>
-              </div> -->
+    <div class="row">
+        <div class="container-fluid" id="search-options-field">
+          <ul type="none" id="search-options">
+              <li [class.active_view]="Display('all')" (click)="docClick()">All</li>
+              <li [class.active_view]="Display('images')" (click)="imageClick()">Images</li>
+              <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
+              <li class="dropdown">
+                <a href="#" id="tools" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                    Tools
+                </a>
+                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="tools" id="tool-dropdown">
+                  <li (click)="filterByContext()">Context Ranking</li>
+                  <li (click)="filterByDate()">Sort by Date</li>
+                  <li data-toggle="modal" data-target="#myModal" (click)="advancedsearch()">Advanced Search</li>
+                </ul>
+              </li>
+          </ul>
+        </div>
+        <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+            <div class="container-fluid" id="progress-bar">
+                {{message}}
             </div>
-            <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
-                <div class="container-fluid" id="progress-bar">
-                    {{message}}
-                </div>
-                <div class="text-result" *ngIf="Display('all')">
-                    <div *ngFor="let item of items$|async" class="result">
-                        <div class="title">
-                            <a href="{{item.link}}">{{item.title}}</a>
-                        </div>
-                        <div class="link">
-                            <p>{{item.link}}</p>
-                        </div>
-                        <div>
-                            {{item.pubDate|date:'fullDate'}}
-                        </div>
+            <div class="text-result" *ngIf="Display('all')">
+                <div *ngFor="let item of items$|async" class="result">
+                    <div class="title">
+                        <a href="{{item.link}}">{{item.title}}</a>
+                    </div>
+                    <div class="link">
+                        <p>{{item.link}}</p>
+                    </div>
+                    <div>
+                        {{item.pubDate|date:'fullDate'}}
                     </div>
                 </div>
-                <div class="image-result" *ngIf="Display('images')">
-                    <div *ngFor="let item of items$|async">
-                        <img class="res-img" src="{{item.link}}" onerror="this.style.display='none'">
+            </div>
+            <div class="image-result" *ngIf="Display('images')">
+                <div *ngFor="let item of items$|async">
+                    <img class="res-img" src="{{item.link}}" onerror="this.style.display='none'">
+                </div>
+            </div>
+            <div class="video-result" *ngIf="Display('videos')">
+                <div *ngFor="let item of items$|async" class="result">
+                    <div class="title">
+                        <a href="{{item.path}}">{{item.title}}</a>
+                    </div>
+                    <div class="link">
+                        <p>{{item.link}}</p>
                     </div>
                 </div>
-                <div class="video-result" *ngIf="Display('videos')">
-                    <div *ngFor="let item of items$|async" class="result">
-                        <div class="title">
-                            <a href="{{item.path}}">{{item.title}}</a>
-                        </div>
-                        <div class="link">
-                            <p>{{item.link}}</p>
-                        </div>
-                    </div>
-                </div>
-                <br>
-                <div class="pagination-property">
-                    <nav aria-label="Page navigation">
-                        <ul class="pagination" id="pag-bar">
-                            <li class="page-item"><span class="page-link" href="#" (click)="decPresentPage()">Previous</span></li>
-                            <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link"
-                                                                             *ngIf="presentPage>=4 && num<=noOfPages"
-                                                                             [class.active_page]="getStyle(presentPage-3+num)"
-                                                                             (click)="getPresentPage(presentPage-3+num)"
-                                                                             href="#">{{presentPage-3+num}}</span>
-                                <span class="page-link" *ngIf="presentPage<4 && num<=noOfPages" [class.active_page]="getStyle(num)"
-                  (click)="getPresentPage(num)" href="#">{{num+1}}</span></li>
-                            <li class="page-item"><span class="page-link" (click)="incPresentPage()">Next</span></li>
-                        </ul>
-                    </nav>
-                </div>
+            </div>
+            <br>
+            <div class="pagination-property">
+                <nav aria-label="Page navigation">
+                    <ul class="pagination" id="pag-bar">
+                        <li class="page-item"><span class="page-link" href="#" (click)="decPresentPage()">Previous</span></li>
+                        <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link"
+                                                                         *ngIf="presentPage>=4 && num<=noOfPages"
+                                                                         [class.active_page]="getStyle(presentPage-3+num)"
+                                                                         (click)="getPresentPage(presentPage-3+num)"
+                                                                         href="#">{{presentPage-3+num}}</span>
+                            <span class="page-link" *ngIf="presentPage<4 && num<=noOfPages" [class.active_page]="getStyle(num)"
+                                  (click)="getPresentPage(num)" href="#">{{num+1}}</span></li>
+                        <li class="page-item"><span class="page-link" (click)="incPresentPage()">Next</span></li>
+                    </ul>
+                </nav>
             </div>
         </div>
-    <!-- </div> -->
+    </div>
     <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
         <app-advancedsearch></app-advancedsearch>
     </div>


### PR DESCRIPTION
Due to some merge conflicts in the previous PR the results page was disoriented and looked like this:
![17354689_1537664536276197_1291996077_n](https://cloud.githubusercontent.com/assets/15105247/23936169/7f28fcac-0976-11e7-87b2-c094681d261c.png)
Now it has been fixed:
![screenshot from 2017-03-15 11 57 52](https://cloud.githubusercontent.com/assets/15105247/23936218/cd892908-0976-11e7-8d49-98c006d02ce0.png)
