### PR TITLE
Fixes #145 Updated top right expansion menu

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -29,7 +29,7 @@
 }
 
 .dropdown-menu{
-  width: 400px;
+  width: 200px;
 }
 
 #navcontainer ul {
@@ -53,18 +53,6 @@
   #navcontainer, #side-menu {
     margin-top: 8px;
   }
-}
-
-#tutorial-icon {
-    padding-left: 15px;
-}
-
-#github-icon {
-    padding-left: 5px;
-}
-
-#bug-icon {
-    padding-left: 10px;
 }
 
 @media screen and (max-width:1079px) {
@@ -111,4 +99,8 @@
   .navbar-brand{
       margin-left: 30%;
   }
+}
+
+.fa {
+  color: #808080;
 }

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -21,42 +21,30 @@
                         <ul class="dropdown-menu">
                             <li>
                                 <div class="header" id="header-download">
-                                    <a href="//yacy.net" target="_blank">
-                                        <i class="fa fa-download" aria-hidden="true" style="font-size: 4em"></i>
-                                        <p class="header-text">Download</p>
+                                    <a href="//blog.fossasia.org" target="_blank">
+                                        <i class="fa fa-newspaper-o" aria-hidden="true" style="font-size: 4em" id="blog-icon"></i>
+                                        <p class="header-text">Blog</p>
                                     </a>
                                 </div>
-                                <div class="header" id="header-community">
-                                    <a href="//forum.yacy.de" target="_blank">
-                                        <i class="fa fa-users" aria-hidden="true" style="font-size: 4em"></i>
+                                <div class="header" id="header-code">
+                                    <a href="//github.com/fossasia/susper.com" target="_blank">
+                                        <i class="fa fa-code" aria-hidden="true" style="font-size: 4em" id="code-icon"></i>
+                                        <p class="header-text">Code</p>
                                     </a>
-                                    <p class="header-text">Community</p>
-                                </div>
-                                <div class="header" id="header-wiki">
-                                    <a href="//wiki.yacy.de" target="_blank">
-                                        <i class="fa fa-wikipedia-w" aria-hidden="true" style="font-size: 4em"></i>
-                                    </a>
-                                    <p class="header-text">Wiki</p>
                                 </div>
                             </li>
                             <li>
                                 <div class="header" id="header-git">
-                                    <a href="//github.com/yacy/yacy_search_server/commits/master" target="_blank">
+                                    <a href="//github.com/fossasia/susper.com" target="_blank">
                                         <i class="fa fa-github" aria-hidden="true" style="font-size: 4em" id="github-icon"></i>
                                     </a>
                                     <p class="header-text">Github</p>
                                 </div>
                                 <div class="header" id="header-bugs">
-                                    <a href="//bugs.yacy.net" target="_blank">
+                                    <a href="//github.com/fossasia/susper.com/issues" target="_blank">
                                         <i class="fa fa-bug" aria-hidden="true" style="font-size: 4em" id="bug-icon"></i>
                                     </a>
-                                    <p class="header-text">Bug</p>
-                                </div>
-                                <div class="header">
-                                    <a href="//yacy.net/tutorials/">
-                                        <i class="fa fa-play" aria-hidden="true" style="font-size: 4em" id="tutorial-icon"></i>
-                                    </a>
-                                    <p class="header-text"> Tutorial</p>
+                                    <p class="header-text">Bug Reports</p>
                                 </div>
                             </li>
                         </ul>


### PR DESCRIPTION
Things I have done in this PR : 

- Took out the icons of download, community, wiki and tutorial.
- Matched the grey color of the icons with the submenu.
-  Changed the links of Github, and bug reports (renamed)
- Added other icons, Code and Blog with their respective links.

![selection_028](https://cloud.githubusercontent.com/assets/22245418/24723766/5f237c7e-1a66-11e7-9824-d2653f14d1ad.png)
