### PR TITLE
add styles to about us page and fixes #150

### DIFF
--- a/src/app/about/about.component.css
+++ b/src/app/about/about.component.css
@@ -33,16 +33,69 @@
     font-weight: 700;
 }
 
-@media screen and (max-width:990px){
-    .image-banner{
+@media screen and (max-width:990px) {
+    .image-banner {
         height: 190px;
     }
-
-    .banner{
-        top:0;
+    .banner {
+        top: 0;
     }
+}
+
+.about-navbar {
+    position: relative;
+    top: -5px;
 }
 
 .navbar {
     margin-bottom: 0px !important;
+}
+
+.nav-about {
+    clear: both;
+    margin: -57px 0 0 0
+}
+
+.sub-details {
+    font-family: Roboto, sans-serif;
+    line-height: 1.4;
+    font-size: 14px;
+}
+
+.sub-details h5 {
+    font-family: Roboto, sans-serif;
+    line-height: 1.4;
+    font-size: 14px;
+    margin: 20px 0 20px 0;
+}
+
+.sub-details p {
+    font-family: Roboto, sans-serif;
+    line-height: 1.4;
+    font-size: 14px;
+    text-align: justify;
+}
+
+.about-sub-details {
+    padding: 20px 0 20px 0;
+    border-top: 1px solid #eee;
+    border-bottom: 1px solid #eee;
+}
+
+.about-sub-details .row h2 {
+    font-family: "Quicksand", sans-serif;
+    padding: 5px 10px;
+    font-weight: 500;
+    font-size: 24px;
+}
+
+.contact-sub-details {
+    margin-bottom: 40px;
+}
+
+.contact-sub-details .row h2 {
+    font-family: "Quicksand", sans-serif;
+    padding: 5px 10px;
+    font-weight: 500;
+    font-size: 24px;
 }

--- a/src/app/about/about.component.css
+++ b/src/app/about/about.component.css
@@ -99,3 +99,6 @@
     font-weight: 500;
     font-size: 24px;
 }
+.navbar-fixed-bottom, .navbar-fixed-top{
+    position: relative !important;
+}

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,37 +1,68 @@
 <!-- Start ignoring BootLintBear-->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-<link href="https://fonts.googleapis.com/css?family=Quicksand" rel="stylesheet"> 
+<link href="https://fonts.googleapis.com/css?family=Quicksand" rel="stylesheet">
 <!-- Stop ignoring BootLintBear-->
-<nav class="navbar navbar-default">
+<nav class="navbar navbar-default nav-about">
     <div class="container-fluid">
         <div class="navbar-header">
-            <a class="navbar-brand" href="//susper.com">
+            <a class="navbar-brand about-navbar" href="//susper.com">
                 <img alt="brand" class="navbar-logo" src="../../assets/images/susper.svg">
             </a>
         </div>
         <p class="navbar-text navbar-right">About Page</p>
     </div>
-</nav>  
+</nav>
 <div class="image-banner">
     <img src="../../assets/images/mountain.jpg" class="img-responsive banner">
 </div>
 <div class="container">
     <br>
-    <h2 class="text-center">Susper is a decentral Search Engine that uses the peer to peer system 'YaCy' and 'Apache Solr' to crawl and index search results.</h2>
+    <h2 class="text-center">Susper is a decentral Search Engine that uses the peer to peer system 'YaCy' and 'Apache Solr' to crawl and index search
+        results.
+    </h2>
     <br>
-    <div class="row">
-        <div class="col-lg-4 col-sm-12">
-            <h5 class="bold">About YaCy</h5>
-            <p>YaCy is a free search engine that anyone can use to build a search portal for their intranet or to help search the public internet. Read more about YaCy here - <a href="https://yacy.net/en/index.html" target="_blank">YaCy Decentralized Web Search</a></p>
+    <div class="about-sub-details">
+        <div class="row">
+            <h2 class="bold">About Us</h2>
         </div>
-        <div class="col-lg-4 col-sm-12">
-            <h5 class="bold">Communication</h5>
-            <p>Facing issues while setting up project on local environment? Our chat channel is on gitter here: <a href="https://gitter.im/fossasia/susper.com" target="_blank">fossasia/susper.com</a> We'll be happy to help you out!'</p>    
+        <div class="row">
+            <div class="col-lg-4 col-sm-12 sub-details">
+                <h5 class="bold">About YaCy</h5>
+                <p>YaCy is a free search engine that anyone can use to build a search portal for their intranet or to help search
+                    the public internet. Read more about YaCy here - <a href="https://yacy.net/en/index.html" target="_blank">YaCy Decentralized Web Search</a></p>
+            </div>
+            <div class="col-lg-4 col-sm-12 sub-details">
+                <h5 class="bold">Communication</h5>
+                <p>Facing issues while setting up project on local environment? Our chat channel is on gitter here: <a href="https://gitter.im/fossasia/susper.com"
+                        target="_blank">fossasia/susper.com</a> We'll be happy to help you out!'</p>
+            </div>
+            <div class="col-lg-4 col-sm-12 sub-details">
+                <h5 class="bold">Contribute to our project</h5>
+                <p>Get involved as an Open Source developer, designer or tester and start your adventure today! Solve an issue
+                    or feature request on our repositories with <a href="https://github.com/fossasia/susper.com" target="_blank">FOSSASIA</a>Build
+                    up your developer profile and become part of a fantastic community.</p>
+            </div>
         </div>
-        <div class="col-lg-4 col-sm-12">
-            <h5 class="bold">Contribute to our project</h5>
-            <p>Get involved as an Open Source developer, designer or tester and start your adventure today! Solve an issue or feature request on our repositories with <a href="https://github.com/fossasia/susper.com" target="_blank">FOSSASIA</a>Build up your developer profile and become part of a fantastic community.</p>
+        <!--About Us details ends-->
+    </div>
+    <!--about-sub-details ends here-->
+
+    <div class="contact-sub-details">
+        <div class="row">
+            <h2 class="bold">Contact Us</h2>
+        </div>
+        <div class="row">
+            <div class="col-lg-12 col-sm-12 contact-sub-details">
+                <p>If you would like to get in touch with us, you find our details on the <a href="contact">contact page.</a></p>
+            </div>
+
         </div>
     </div>
+    <!--contact-sub-details ends here-->
+
     <br>
 </div>
+<footer>
+    <!--footer navigation bar goes here-->
+    <app-footer-navbar></app-footer-navbar>
+</footer>

--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -1,6 +1,23 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By, BrowserModule } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
 
 import { AboutComponent } from './about.component';
+import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { JsonpModule, HttpModule } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { reducer } from '../reducers/index';
+import { FormsModule } from '@angular/forms';
+import { AppComponent } from '../app.component';
+import { NavbarComponent } from '../navbar/navbar.component';
+import { IndexComponent } from '../index/index.component';
+import { ResultsComponent } from '../results/results.component';
+import { NotFoundComponent } from '../not-found/not-found.component';
+import { AdvancedsearchComponent } from '../advancedsearch/advancedsearch.component';
+import { SearchBarComponent } from '../search-bar/search-bar.component';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -8,9 +25,29 @@ describe('AboutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AboutComponent ]
+      imports: [
+        RouterTestingModule,
+        BrowserModule,
+        CommonModule,
+        FormsModule,
+        HttpModule,
+        JsonpModule,
+        StoreModule.provideStore(reducer),
+        StoreDevtoolsModule.instrumentOnlyWithExtension(),
+      ],
+      declarations: [
+        AppComponent,
+        NavbarComponent,
+        IndexComponent,
+        ResultsComponent,
+        NotFoundComponent,
+        AdvancedsearchComponent,
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/advancedsearch/advancedsearch.component.spec.ts
+++ b/src/app/advancedsearch/advancedsearch.component.spec.ts
@@ -17,6 +17,8 @@ import {IndexComponent} from '../index/index.component';
 import {ResultsComponent} from '../results/results.component';
 import {NotFoundComponent} from '../not-found/not-found.component';
 import {SearchBarComponent} from '../search-bar/search-bar.component';
+import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
+import { AboutComponent } from '../about/about.component';
 
 describe('AdvancedsearchComponent', () => {
   let component: AdvancedsearchComponent;
@@ -24,7 +26,8 @@ describe('AdvancedsearchComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         BrowserModule,
         CommonModule,
         FormsModule,
@@ -40,7 +43,9 @@ describe('AdvancedsearchComponent', () => {
         ResultsComponent,
         NotFoundComponent,
         AdvancedsearchComponent,
-        SearchBarComponent
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
       ]
     })
       .compileComponents();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,26 +2,29 @@
 
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
-import {IndexComponent} from './index/index.component';
-import {NavbarComponent} from './navbar/navbar.component';
+import { IndexComponent } from './index/index.component';
+import { NavbarComponent } from './navbar/navbar.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import {ResultsComponent} from './results/results.component';
-import {NotFoundComponent} from './not-found/not-found.component';
-import {AdvancedsearchComponent} from './advancedsearch/advancedsearch.component';
-import {SearchBarComponent} from './search-bar/search-bar.component';
-import {BrowserModule} from '@angular/platform-browser';
-import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {HttpModule, JsonpModule} from '@angular/http';
-import {RouterModule} from '@angular/router';
-import {StoreModule} from '@ngrx/store';
-import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {reducer} from './reducers/index';
+import { ResultsComponent } from './results/results.component';
+import { NotFoundComponent } from './not-found/not-found.component';
+import { AdvancedsearchComponent } from './advancedsearch/advancedsearch.component';
+import { SearchBarComponent } from './search-bar/search-bar.component';
+import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, JsonpModule } from '@angular/http';
+import { RouterModule } from '@angular/router';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { reducer } from './reducers/index';
+import { FooterNavbarComponent } from './footer-navbar/footer-navbar.component';
+import { AboutComponent } from './about/about.component';
 
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         BrowserModule,
         CommonModule,
         FormsModule,
@@ -37,7 +40,9 @@ describe('AppComponent', () => {
         ResultsComponent,
         NotFoundComponent,
         AdvancedsearchComponent,
-        SearchBarComponent
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
       ],
     });
     TestBed.compileComponents();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import {StoreModule} from '@ngrx/store';
 import {reducer} from './reducers/index';
 import { SearchBarComponent } from './search-bar/search-bar.component';
 import { AboutComponent } from './about/about.component';
+import { FooterNavbarComponent } from './footer-navbar/footer-navbar.component';
 
 const appRoutes: Routes = [
   {path: 'search', component: ResultsComponent},
@@ -33,7 +34,8 @@ const appRoutes: Routes = [
     NotFoundComponent,
     AdvancedsearchComponent,
     SearchBarComponent,
-    AboutComponent
+    AboutComponent,
+    FooterNavbarComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/footer-navbar/footer-navbar.component.css
+++ b/src/app/footer-navbar/footer-navbar.component.css
@@ -1,0 +1,5 @@
+.fixed-bottom{
+    position: relative;
+    bottom: 0px;
+    margin: 0;
+}

--- a/src/app/footer-navbar/footer-navbar.component.html
+++ b/src/app/footer-navbar/footer-navbar.component.html
@@ -1,0 +1,20 @@
+<nav class="navbar navbar-default navbar-fixed-bottom" role="navigation">
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                </button>
+  </div>
+  <div class="navbar-collapse collapse">
+    <ul class="nav navbar-nav navbar-left">
+      <li><a routerLink="/about" routerLinkActive="active">About Susper</a></li>
+      <li><a href="//blog.fossasia.org">Blogs</a></li>
+      <li><a href="//github.com/fossasia/susper.com">Code</a></li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li><a href="#">Terms</a></li>
+      <li><a href="#">Contact</a></li>
+    </ul>
+  </div>
+</nav>

--- a/src/app/footer-navbar/footer-navbar.component.html
+++ b/src/app/footer-navbar/footer-navbar.component.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default navbar-fixed-bottom" role="navigation">
+<nav class="navbar navbar-default fixed-bottom" role="navigation">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                     <span class="icon-bar"></span>

--- a/src/app/footer-navbar/footer-navbar.component.spec.ts
+++ b/src/app/footer-navbar/footer-navbar.component.spec.ts
@@ -1,0 +1,28 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+
+import { FooterNavbarComponent } from './footer-navbar.component';
+
+describe('FooterNavbarComponent', () => {
+  let component: FooterNavbarComponent;
+  let fixture: ComponentFixture<FooterNavbarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FooterNavbarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FooterNavbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/footer-navbar/footer-navbar.component.spec.ts
+++ b/src/app/footer-navbar/footer-navbar.component.spec.ts
@@ -1,9 +1,23 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import { By, BrowserModule } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { FooterNavbarComponent } from './footer-navbar.component';
+import { AboutComponent } from '../about/about.component';
+import { AppComponent } from '../app.component';
+import { NavbarComponent } from '../navbar/navbar.component';
+import { IndexComponent } from '../index/index.component';
+import { ResultsComponent } from '../results/results.component';
+import { NotFoundComponent } from '../not-found/not-found.component';
+import { AdvancedsearchComponent } from '../advancedsearch/advancedsearch.component';
+import { SearchBarComponent } from '../search-bar/search-bar.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, JsonpModule } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { reducer } from '../reducers/search';
 
 describe('FooterNavbarComponent', () => {
   let component: FooterNavbarComponent;
@@ -11,9 +25,29 @@ describe('FooterNavbarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ FooterNavbarComponent ]
+      imports: [
+        RouterTestingModule,
+        BrowserModule,
+        CommonModule,
+        FormsModule,
+        HttpModule,
+        JsonpModule,
+        StoreModule.provideStore(reducer),
+        StoreDevtoolsModule.instrumentOnlyWithExtension(),
+      ],
+      declarations: [FooterNavbarComponent,
+        AppComponent,
+        NavbarComponent,
+        IndexComponent,
+        ResultsComponent,
+        NotFoundComponent,
+        AdvancedsearchComponent,
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/footer-navbar/footer-navbar.component.ts
+++ b/src/app/footer-navbar/footer-navbar.component.ts
@@ -1,11 +1,9 @@
-import { Component, OnInit, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-footer-navbar',
   templateUrl: './footer-navbar.component.html',
-  styleUrls: ['./footer-navbar.component.css'],
-  encapsulation: ViewEncapsulation.null,
-  changeDetection: ChangeDetectionStrategy.null
+  styleUrls: ['./footer-navbar.component.css']
 })
 export class FooterNavbarComponent implements OnInit {
 

--- a/src/app/footer-navbar/footer-navbar.component.ts
+++ b/src/app/footer-navbar/footer-navbar.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'app-footer-navbar',
+  templateUrl: './footer-navbar.component.html',
+  styleUrls: ['./footer-navbar.component.css'],
+  encapsulation: ViewEncapsulation.null,
+  changeDetection: ChangeDetectionStrategy.null
+})
+export class FooterNavbarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/index/index.component.css
+++ b/src/app/index/index.component.css
@@ -72,3 +72,9 @@
 .navbar-toggle {
     z-index:3;
 }
+footer{
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    width:100%;
+}

--- a/src/app/index/index.component.html
+++ b/src/app/index/index.component.html
@@ -18,25 +18,8 @@
             <app-search-bar></app-search-bar>
         </div>
         <footer>
-          <nav class="navbar navbar-default navbar-fixed-bottom" role="navigation">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                    <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                </button>    
-            </div>
-            <div class="navbar-collapse collapse">
-                <ul class="nav navbar-nav navbar-left">
-                    <li><a routerLink="/about" routerLinkActive="active">About Susper</a></li>
-                    <li><a href="//blog.fossasia.org">Blogs</a></li>
-                    <li><a href="//github.com/fossasia/susper.com">Code</a></li>
-                </ul>
-                <ul class="nav navbar-nav navbar-right">
-                    <li><a href="#">Terms</a></li>
-                    <li><a href="#">Contact</a></li>
-                </ul>
-            </div>
-          </nav>
+            <!--footer navigation bar goes here-->
+            <app-footer-navbar></app-footer-navbar>
         </footer>
-  </div>
+    </div>
+    

--- a/src/app/index/index.component.spec.ts
+++ b/src/app/index/index.component.spec.ts
@@ -1,22 +1,24 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {By, BrowserModule} from '@angular/platform-browser';
+import { By, BrowserModule } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { IndexComponent } from './index.component';
-import {RouterTestingModule} from '@angular/router/testing';
-import {CommonModule} from '@angular/common';
-import {JsonpModule, HttpModule} from '@angular/http';
-import {StoreModule} from '@ngrx/store';
-import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {reducer} from '../reducers/index';
-import {FormsModule} from '@angular/forms';
-import {AppComponent} from '../app.component';
-import {NavbarComponent} from '../navbar/navbar.component';
-import {ResultsComponent} from '../results/results.component';
-import {NotFoundComponent} from '../not-found/not-found.component';
-import {AdvancedsearchComponent} from '../advancedsearch/advancedsearch.component';
-import {SearchBarComponent} from '../search-bar/search-bar.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { JsonpModule, HttpModule } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { reducer } from '../reducers/index';
+import { FormsModule } from '@angular/forms';
+import { AppComponent } from '../app.component';
+import { NavbarComponent } from '../navbar/navbar.component';
+import { ResultsComponent } from '../results/results.component';
+import { NotFoundComponent } from '../not-found/not-found.component';
+import { AdvancedsearchComponent } from '../advancedsearch/advancedsearch.component';
+import { SearchBarComponent } from '../search-bar/search-bar.component';
+import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
+import { AboutComponent } from '../about/about.component';
 
 describe('IndexComponent', () => {
   let component: IndexComponent;
@@ -24,7 +26,8 @@ describe('IndexComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         BrowserModule,
         CommonModule,
         FormsModule,
@@ -40,10 +43,12 @@ describe('IndexComponent', () => {
         ResultsComponent,
         NotFoundComponent,
         AdvancedsearchComponent,
-        SearchBarComponent
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,64 +1,64 @@
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <nav class="navbar navbar-fixed-top navbar-default">
-        <div class="container-fluid">
-            <div class="navbar-header" id="navcontainer">
-              <ul>
+<nav class="navbar navbar-fixed-top navbar-default">
+    <div class="container-fluid">
+        <div class="navbar-header" id="navcontainer">
+            <ul>
                 <li>
-                  <a href="/">
-                    <img class="navbar-brand" src="assets/images/susper.svg">
-                  </a>
+                    <a href="/">
+                        <img class="navbar-brand" src="assets/images/susper.svg">
+                    </a>
                 </li>
                 <li id="navbar-search">
                     <app-search-bar></app-search-bar>
                 </li>
-              </ul>
-            </div>
-
-            <div class="navbar-collapse collapse" style="display:none" id="side-menu">
-                <ul class="nav navbar-nav navbar-right">
-                    <li class="dropdown">
-                        <a href="#" data-toggle="dropdown" class="dropdown-toggle" data-proofer-ignore><i class="fa fa-bars" aria-hidden="true" style="font-size: 2em"></i></a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <div class="header" id="header-download">
-                                    <a href="//blog.fossasia.org" target="_blank">
-                                        <i class="fa fa-newspaper-o" aria-hidden="true" style="font-size: 4em" id="blog-icon"></i>
-                                        <p class="header-text">Blog</p>
-                                    </a>
-                                </div>
-                                <div class="header" id="header-code">
-                                    <a href="//github.com/fossasia/susper.com" target="_blank">
-                                        <i class="fa fa-code" aria-hidden="true" style="font-size: 4em" id="code-icon"></i>
-                                        <p class="header-text">Code</p>
-                                    </a>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="header" id="header-git">
-                                    <a href="//github.com/fossasia/susper.com" target="_blank">
-                                        <i class="fa fa-github" aria-hidden="true" style="font-size: 4em" id="github-icon"></i>
-                                    </a>
-                                    <p class="header-text">Github</p>
-                                </div>
-                                <div class="header" id="header-bugs">
-                                    <a href="//github.com/fossasia/susper.com/issues" target="_blank">
-                                        <i class="fa fa-bug" aria-hidden="true" style="font-size: 4em" id="bug-icon"></i>
-                                    </a>
-                                    <p class="header-text">Bug Reports</p>
-                                </div>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
-            </div>
+            </ul>
         </div>
-    </nav>
 
-    <script>
-      $(document).ready(function(){
+        <div class="navbar-collapse collapse" style="display:none" id="side-menu">
+            <ul class="nav navbar-nav navbar-right">
+                <li class="dropdown">
+                    <a href="#" data-toggle="dropdown" class="dropdown-toggle" data-proofer-ignore><i class="fa fa-bars" aria-hidden="true" style="font-size: 2em"></i></a>
+                    <ul class="dropdown-menu">
+                        <li>
+                            <div class="header" id="header-download">
+                                <a href="//blog.fossasia.org" target="_blank">
+                                    <i class="fa fa-newspaper-o" aria-hidden="true" style="font-size: 4em" id="blog-icon"></i>
+                                    <p class="header-text">Blog</p>
+                                </a>
+                            </div>
+                            <div class="header" id="header-code">
+                                <a href="//github.com/fossasia/susper.com" target="_blank">
+                                    <i class="fa fa-code" aria-hidden="true" style="font-size: 4em" id="code-icon"></i>
+                                    <p class="header-text">Code</p>
+                                </a>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="header" id="header-git">
+                                <a href="//github.com/fossasia/susper.com" target="_blank">
+                                    <i class="fa fa-github" aria-hidden="true" style="font-size: 4em" id="github-icon"></i>
+                                </a>
+                                <p class="header-text">Github</p>
+                            </div>
+                            <div class="header" id="header-bugs">
+                                <a href="//github.com/fossasia/susper.com/issues" target="_blank">
+                                    <i class="fa fa-bug" aria-hidden="true" style="font-size: 4em" id="bug-icon"></i>
+                                </a>
+                                <p class="header-text">Bug Reports</p>
+                            </div>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<script>
+    $(document).ready(function () {
         var isFirefox = typeof InstallTrigger !== 'undefined';
-        if(isFirefox === false){
-          $("#navbar-search").addClass("align-navsearch-btn");
+        if (isFirefox === false) {
+            $("#navbar-search").addClass("align-navsearch-btn");
         }
-      }
-    </script>
+    }
+</script>

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -1,22 +1,24 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {By, BrowserModule} from '@angular/platform-browser';
+import { By, BrowserModule } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { NavbarComponent } from './navbar.component';
-import {RouterTestingModule} from '@angular/router/testing';
-import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {HttpModule, JsonpModule} from '@angular/http';
-import {StoreModule} from '@ngrx/store';
-import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {AppComponent} from '../app.component';
-import {IndexComponent} from '../index/index.component';
-import {ResultsComponent} from '../results/results.component';
-import {NotFoundComponent} from '../not-found/not-found.component';
-import {AdvancedsearchComponent} from '../advancedsearch/advancedsearch.component';
-import {SearchBarComponent} from '../search-bar/search-bar.component';
-import {reducer} from '../reducers/index';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, JsonpModule } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { AppComponent } from '../app.component';
+import { IndexComponent } from '../index/index.component';
+import { ResultsComponent } from '../results/results.component';
+import { NotFoundComponent } from '../not-found/not-found.component';
+import { AdvancedsearchComponent } from '../advancedsearch/advancedsearch.component';
+import { SearchBarComponent } from '../search-bar/search-bar.component';
+import { reducer } from '../reducers/index';
+import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
+import { AboutComponent } from '../about/about.component';
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
@@ -24,7 +26,8 @@ describe('NavbarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         BrowserModule,
         CommonModule,
         FormsModule,
@@ -40,10 +43,12 @@ describe('NavbarComponent', () => {
         ResultsComponent,
         NotFoundComponent,
         AdvancedsearchComponent,
-        SearchBarComponent
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/not-found/not-found.component.spec.ts
+++ b/src/app/not-found/not-found.component.spec.ts
@@ -1,22 +1,24 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {By, BrowserModule} from '@angular/platform-browser';
+import { By, BrowserModule } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { NotFoundComponent } from './not-found.component';
-import {RouterTestingModule} from '@angular/router/testing';
-import {CommonModule} from '@angular/common';
-import {HttpModule, JsonpModule} from '@angular/http';
-import {StoreModule} from '@ngrx/store';
-import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {reducer} from '../reducers/index';
-import {AppComponent} from '../app.component';
-import {NavbarComponent} from '../navbar/navbar.component';
-import {IndexComponent} from '../index/index.component';
-import {ResultsComponent} from '../results/results.component';
-import {AdvancedsearchComponent} from '../advancedsearch/advancedsearch.component';
-import {SearchBarComponent} from '../search-bar/search-bar.component';
-import {FormsModule} from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { HttpModule, JsonpModule } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { reducer } from '../reducers/index';
+import { AppComponent } from '../app.component';
+import { NavbarComponent } from '../navbar/navbar.component';
+import { IndexComponent } from '../index/index.component';
+import { ResultsComponent } from '../results/results.component';
+import { AdvancedsearchComponent } from '../advancedsearch/advancedsearch.component';
+import { SearchBarComponent } from '../search-bar/search-bar.component';
+import { FormsModule } from '@angular/forms';
+import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
+import { AboutComponent } from '../about/about.component';
 
 describe('NotFoundComponent', () => {
   let component: NotFoundComponent;
@@ -24,7 +26,8 @@ describe('NotFoundComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         BrowserModule,
         CommonModule,
         FormsModule,
@@ -40,10 +43,12 @@ describe('NotFoundComponent', () => {
         ResultsComponent,
         NotFoundComponent,
         AdvancedsearchComponent,
-        SearchBarComponent
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/results/results.component.spec.ts
+++ b/src/app/results/results.component.spec.ts
@@ -1,23 +1,25 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {By, BrowserModule} from '@angular/platform-browser';
+import { By, BrowserModule } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { ResultsComponent } from './results.component';
-import {RouterTestingModule} from '@angular/router/testing';
-import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {HttpModule, JsonpModule} from '@angular/http';
-import {StoreModule} from '@ngrx/store';
-import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {reducer} from '../reducers/index';
-import {AppComponent} from '../app.component';
-import {NavbarComponent} from '../navbar/navbar.component';
-import {IndexComponent} from '../index/index.component';
-import {NotFoundComponent} from '../not-found/not-found.component';
-import {AdvancedsearchComponent} from '../advancedsearch/advancedsearch.component';
-import {SearchBarComponent} from '../search-bar/search-bar.component';
-import {SearchService} from '../search.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, JsonpModule } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { reducer } from '../reducers/index';
+import { AppComponent } from '../app.component';
+import { NavbarComponent } from '../navbar/navbar.component';
+import { IndexComponent } from '../index/index.component';
+import { NotFoundComponent } from '../not-found/not-found.component';
+import { AdvancedsearchComponent } from '../advancedsearch/advancedsearch.component';
+import { SearchBarComponent } from '../search-bar/search-bar.component';
+import { SearchService } from '../search.service';
+import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
+import { AboutComponent } from '../about/about.component';
 
 describe('ResultsComponent', () => {
   let component: ResultsComponent;
@@ -25,7 +27,8 @@ describe('ResultsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         BrowserModule,
         CommonModule,
         FormsModule,
@@ -41,11 +44,14 @@ describe('ResultsComponent', () => {
         ResultsComponent,
         NotFoundComponent,
         AdvancedsearchComponent,
-        SearchBarComponent
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
+
       ],
       providers: [SearchService]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/search-bar/search-bar.component.spec.ts
+++ b/src/app/search-bar/search-bar.component.spec.ts
@@ -1,22 +1,24 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {By, BrowserModule} from '@angular/platform-browser';
+import { By, BrowserModule } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { SearchBarComponent } from './search-bar.component';
-import {RouterTestingModule} from '@angular/router/testing';
-import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {HttpModule, JsonpModule} from '@angular/http';
-import {StoreModule} from '@ngrx/store';
-import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {reducer} from '../reducers/index';
-import {AppComponent} from '../app.component';
-import {NavbarComponent} from '../navbar/navbar.component';
-import {IndexComponent} from '../index/index.component';
-import {ResultsComponent} from '../results/results.component';
-import {NotFoundComponent} from '../not-found/not-found.component';
-import {AdvancedsearchComponent} from '../advancedsearch/advancedsearch.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, JsonpModule } from '@angular/http';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { reducer } from '../reducers/index';
+import { AppComponent } from '../app.component';
+import { NavbarComponent } from '../navbar/navbar.component';
+import { IndexComponent } from '../index/index.component';
+import { ResultsComponent } from '../results/results.component';
+import { NotFoundComponent } from '../not-found/not-found.component';
+import { AdvancedsearchComponent } from '../advancedsearch/advancedsearch.component';
+import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
+import { AboutComponent } from '../about/about.component';
 
 describe('SearchBarComponent', () => {
   let component: SearchBarComponent;
@@ -25,7 +27,8 @@ describe('SearchBarComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
 
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         BrowserModule,
         CommonModule,
         FormsModule,
@@ -41,9 +44,12 @@ describe('SearchBarComponent', () => {
         ResultsComponent,
         NotFoundComponent,
         AdvancedsearchComponent,
-        SearchBarComponent
-      ]    })
-    .compileComponents();
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent
+      ]
+    })
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -68,10 +74,10 @@ describe('SearchBarComponent', () => {
     expect(document.activeElement).toBe(inputElement);
   });
 
-   it('should have "searchdata" property', () => {
-     let compiled = fixture.debugElement.nativeElement;
+  it('should have "searchdata" property', () => {
+    let compiled = fixture.debugElement.nativeElement;
 
-     expect(component.searchdata).toBeTruthy();
-   });
+    expect(component.searchdata).toBeTruthy();
+  });
 
 });


### PR DESCRIPTION
- add contact us details area to page.
- add bottom navigation bar.
- made a new component and that includes footer navigation bar.
![screencapture-localhost-4200-about-1491757811121](https://cloud.githubusercontent.com/assets/7692626/24839343/d860c4e0-1d75-11e7-8323-66cc7a24a006.png)
