### PR TITLE
Hide "Next" and "Previous" navigations 

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -57,7 +57,7 @@
         </div>
         <br>
         <div class="pagination-property">
-            <nav aria-label="Page navigation">
+            <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
                 <ul class="pagination" id="pag-bar">
                     <li class="page-item"><span class="page-link" href="#" (click)="decPresentPage()">Previous</span></li>
                     <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link" *ngIf="presentPage>=4 && num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"


### PR DESCRIPTION
Now it does not show  "Next" and "Previous" buttons when there is no search result.
this fixes #170 
<img width="1166" alt="screen shot 2017-04-23 at 3 32 16 pm" src="https://cloud.githubusercontent.com/assets/7692626/25312555/1a521920-283a-11e7-9ae1-f5d009a108da.png">
