### PR TITLE
Fixes #186, Top bar is fixed to avoid page seperation

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -7,10 +7,12 @@
   width: 60px;
   height: 50px;
 }
+
 .top-nav{
   margin-bottom: 0px;
   margin-top: -5%;
 }
+
 .menu-drop-image{
   width: 25px;
   height: auto;

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -7,7 +7,10 @@
   width: 60px;
   height: 50px;
 }
-
+.top-nav{
+  margin-bottom: 0px;
+  margin-top: -5%;
+}
 .menu-drop-image{
   width: 25px;
   height: auto;

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-fixed-top navbar-default">
+<nav class="top-nav navbar navbar-static-top navbar-default">
     <div class="container-fluid">
         <div class="navbar-header" id="navcontainer">
             <ul>


### PR DESCRIPTION
Fixes #186, 
![image](https://cloud.githubusercontent.com/assets/20185076/25750359/1568981e-31cf-11e7-9811-7788b3cd6b77.png)

on scrolling down:
![image](https://cloud.githubusercontent.com/assets/20185076/25750390/2f2fab16-31cf-11e7-8b8d-1ebeb526fa5a.png)
