### PR TITLE
Fixes #205 Improve top menu on pages and add links

### DIFF
--- a/src/app/about/about.component.css
+++ b/src/app/about/about.component.css
@@ -102,3 +102,26 @@
 .navbar-fixed-bottom, .navbar-fixed-top{
     position: relative !important;
 }
+
+.contents {
+    text-align: right;
+}
+
+a {
+    text-decoration: none;
+    padding-right: 30px;
+    color: rgb(119,119,119);
+}
+
+.navbar-collapse.navbar-right {
+    padding-top: 15px;
+}
+
+a:hover {
+    color: rgb(51,51,51);
+    text-decoration: none;
+}
+
+.navbar-brand {
+    padding-left: 100px;
+}

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -9,9 +9,14 @@
                 <img alt="brand" class="navbar-logo" src="../../assets/images/susper.svg">
             </a>
         </div>
-        <p class="navbar-text navbar-right">About Page</p>
+        <p class="navbar-collapse navbar-right">
+            <a href="/terms">Terms</a>
+            <a href="/about">About</a>
+            <a href="/contact">Contact</a>
+        </p>
     </div>
 </nav>
+
 <div class="image-banner">
     <img src="../../assets/images/mountain.jpg" class="img-responsive banner">
 </div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,7 +43,6 @@ const appRoutes: Routes = [
     FooterNavbarComponent,
     ContactComponent,
     TermsComponent
-    
   ],
   imports: [
     BrowserModule,


### PR DESCRIPTION
Resolves #205 

Things I have done in this PR : 
- Created a new `TopbarComponent`
- Did improvements in the top menu on the about page and added links as per issue.

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>. Though, preview link may not load the `about` page. I'm providing the screenshot of the following work as well -

![selection_037](https://cloud.githubusercontent.com/assets/22245418/25762898/30493b3c-31fe-11e7-8117-4d52c18d8b29.png)

I'm facing one problem, regarding padding from top (as in screenshot). It is leaving a lot of blank space.  I tried to solve it, but happens nothing. It would be great if someone, can help me out in this! :smile: 