### PR TITLE
Fixes #183 Add susper as standard search engine to Chrome

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,26 +28,31 @@
 </div>
 -->
 <script>
-  $(document).ready(function(){
-    var isFirefox = typeof InstallTrigger !== 'undefined';
-    if(isFirefox === false){
-      $("#set-susper-default").remove();
-      $(".input-group-btn").addClass("align-search-btn");
-      $("#navbar-search").addClass("align-navsearch-btn");
+  $(document).ready(function () {
+    //var isFirefox = typeof InstallTrigger !== 'undefined';
+
+    //if (isFirefox === false) {
+    //    $("#set-susper-default").remove();
+    //    $(".input-group-btn").addClass("align-search-btn");
+    //    $("#navbar-search").addClass("align-navsearch-btn");
+    //}
+
+    if (window.external && window.external.IsSearchProviderInstalled) {
+        var isInstalled = window.external.IsSearchProviderInstalled("http://susper.com");
+
+        if (!isInstalled) {
+            $("#set-susper-default").show();
+        }
     }
-    if(window.external && window.external.IsSearchProviderInstalled){
-      var isInstalled = window.external.IsSearchProviderInstalled("http://susper.com");
-      if(!isInstalled){
-        $("#set-susper-default").show();
-      }
-    }
-    $("#install-susper").on("click", function(){
-      window.external.AddSearchProvider("http://susper.com/susper.xml");
+
+    $("#install-susper").on("click", function () {
+        window.external.AddSearchProvider("http://susper.com/susper.xml");
     });
-    $("#cancel-installation").on("click", function(){
-      $("#set-susper-default").remove();
+
+    $("#cancel-installation").on("click", function () {
+        $("#set-susper-default").remove();
     });
-  });
+});
 </script>
 <script>
   (function(){


### PR DESCRIPTION
Resolves #183 

See also - #194 . In my previous PR, I faced a problem while solving conflicts and providing preview link. So created a new PR.

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>. Please ignore the `footer-navbar` issue, it has been raised due to recent pull merged. The commits which I have done in this PR, does not include any file regarding `footer-navbar`.  

Screenshots : 

Chrome/Chromium browser - 

![89ec1052-2ea1-11e7-8c30-cfeafbf46c6d](https://cloud.githubusercontent.com/assets/22245418/25774282/1977d74a-32aa-11e7-9cc5-c65538883a53.png)

Firefox -

![8ee19014-2ea1-11e7-9107-cfbec4641d36](https://cloud.githubusercontent.com/assets/22245418/25774284/278c6c06-32aa-11e7-8f7a-32262830251a.png)