### PR TITLE
Fixes #185 Make results more compact and match them with market leader

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -1,17 +1,25 @@
 .result {
   padding-left: 60px;
-  padding-top: 30px;
+  padding-top: 18px;
 }
 
 .title >a {
-  color: darkblue;
+  color: #1a0dab;
   font-size: large;
   text-decoration: none;
+  font-family: Arial, sans-serif;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .link > p {
   color: #006621;
   text-decoration: none;
+  word-wrap: break-word;
+  font-size: 14px;
+  font-style: normal;
+  font-family: Arial, sans-serif;
 }
 
 .title >a:hover {
@@ -20,6 +28,9 @@
 
 .description {
   text-align: justify;
+  color: #808080;
+  line-height: 1.4;
+  word-wrap: break-word;
 }
 
 .page-link {
@@ -284,4 +295,8 @@ img.res-img {
   #search-options li {
     padding: 0px 5.6% 12px;
   }
+}
+
+p {
+  padding-right: 500px;
 }

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -30,10 +30,7 @@
                     <p>{{item.link}}</p>
                 </div>
                 <div class="description">
-                    <p>{{item.description}}</p>
-                </div>
-                <div>
-                    {{item.pubDate|date:'fullDate'}}
+                    <p>{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Resolves #185 

Preview link <a href="https://harshit98.github.io/susper.com/">here</a>.

Things I have done in this PR : 
- Used same font, color and font size for title, green link and description. 
- Reduce height after lines.
- Move date to beginning of description followed by a dash *-*
- Break description line automatically, and use the width of the search bar.

![selection_041](https://cloud.githubusercontent.com/assets/22245418/25776037/b1d46050-32d0-11e7-82d1-b65b0958ec6b.png)

Problems I'm facing - 
- Show page titles only in the max-width of the search bar and after that "..." : I have used `text-overflow: ellipsis;` , `overflow: hidden;` and `white-space: nowrap;` and still the feature is not working.
- For breaking up the description line I have used `padding: 500px` . Wanted to know, if it will be better or not.
- Unable to give different colors to date and description. Tried to separate them, and assign them different colors according to their class and happens nothing.

It would be great, if someone can help and suggest me what more changes should be done. :+1:  
