### PR TITLE
Fixes #142 Match the features to the search box of market leader

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -124,10 +124,12 @@ img.res-img {
 #search-options li {
   display: inline;
   cursor: pointer;
-  padding: 28px 20px 12px;
+  padding: 28px 16px 12px;
   color: #777;
   font-weight: 500;
   font-size: 13px;
+  line-height: 15px;
+  font-family: Arial, sans-serif;
 }
 
 #search-options li:hover {
@@ -137,7 +139,7 @@ img.res-img {
 #tools {
   text-decoration: none;
   color: #777;
-  margin-left: 23%;
+  margin-left: 27%;
 }
 
 #tools:hover {

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -23,6 +23,8 @@
   border-radius: 0px;
   border: none;
   box-shadow: none;
+  padding-left: 16px;
+  font-family: Arial, sans-serif;
 }
 
 #nav-button{


### PR DESCRIPTION
Resolves #142 

Things done in this PR - 
- fixed the font and font size in the search box.
- fixed and matched sub-menu to the market leader.
- adjust the position of "tools" to match the sample service.

Other features which has been stated in issue #142 were solved in PR #164 

Screenshot : 

Before -

![selection_043](https://cloud.githubusercontent.com/assets/22245418/25776234/9ffa72b0-32d6-11e7-9fa7-050458c55c5d.png)

After -

![selection_042](https://cloud.githubusercontent.com/assets/22245418/25776237/a5e73302-32d6-11e7-9304-29cecb333d48.png)
 