### PR TITLE
Fixes #207 stick the pagination bar to bottom of the image search

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -50,6 +50,7 @@
             </div>
         </div>
         <br>
+        <div class="clean"></div>
         <div class="pagination-property">
             <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
                 <ul class="pagination" id="pag-bar">


### PR DESCRIPTION
this fixes #207 .
stick the pagination bar to bottom of the image search.
this finally looks like this.
<img width="1277" alt="screen shot 2017-05-07 at 7 00 56 am" src="https://cloud.githubusercontent.com/assets/7692626/25777171/f3cff308-32f2-11e7-8799-ce455d9295b2.png">

check thi test link:
https://isuruab.github.io/susper.com/search?query=d&verify=false&nav=filetype%2Cprotocol%2Chosts%2Cauthors%2Ccollections%2Cnamespace%2Ctopics%2Cdate&start=0&indexof=off&meanCount=5&resource=global&prefermaskfilter=&rows=100&timezoneOffset=0&fq=url_file_ext_s%3A(png%2BOR%2Bjpeg%2BOR%2Bjpg%2BOR%2Bgif)