### PR TITLE
Fixes #197, Tools dropdown menu visible on screen

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -35,11 +35,10 @@
 
 .container-fluid{
   position: relative;
-} 
+}
 
 .container-fluid ul{
   padding-top: 6px;
-  width: 685px;
 }
 
 .container-fluid li{
@@ -49,13 +48,13 @@
 }
 
 .container-fluid li a{
-  position: relative; 
+  position: relative;
   left: -25px;
 }
 
 .dropdown-menu > li {
   font-size: small;
-  padding: 5px;
+  padding: 3px;
   text-align: center;
   text-decoration: none;
 }
@@ -145,13 +144,15 @@ img.res-img {
 }
 
 .dropdown-menu {
-  min-width: 140px;
+  left:100%;
+
 }
 
 #tool-dropdown li {
   text-align: left;
   display: block;
-  padding: 4px 12px;
+  padding-top: 16px;
+  padding-bottom: 24px;
 }
 
 #pag-bar {
@@ -169,9 +170,9 @@ img.res-img {
        border: 0px ;
        font-size: 16px;
  }
- 
- .active_page{  
-       color: black; 
+
+ .active_page{
+       color: black;
  }
 
 .image-result {

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -9,7 +9,7 @@
                 <a href="#" id="tools" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     Tools
                 </a>
-                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="tools" id="tool-dropdown">
+                <ul class="dropdown-menu" aria-labelledby="tools" id="tool-dropdown">
                     <li (click)="filterByContext()">Context Ranking</li>
                     <li (click)="filterByDate()">Sort by Date</li>
                     <li data-toggle="modal" data-target="#myModal" (click)="advancedsearch()">Advanced Search</li>


### PR DESCRIPTION
Fixes #197, Fixes padding and margins for the dropdown menu for tools. It now appears on screen.
![image](https://cloud.githubusercontent.com/assets/20185076/25779064/403bdfce-332d-11e7-970a-e9014977f599.png)
