### PR TITLE
Fixes #184, Search bar and header more like market leader

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -7,10 +7,13 @@
   width: 60px;
   height: 50px;
 }
-
+.navbar-default{
+  border-color: #f8f8f8;
+}
 .top-nav{
   margin-bottom: 0px;
   margin-top: -5%;
+  padding-top: 0.4%;
 }
 
 .menu-drop-image{
@@ -32,7 +35,7 @@
 }
 
 .dropdown-menu{
-  width: 100px;    
+  width: 100px;
 }
 
 #navcontainer ul {
@@ -43,7 +46,7 @@
 
 @media screen and (min-width:1920px) {
   .navbar-brand{
-      width: 170px;
+      width: 160px;
       height: auto;
   }
 }
@@ -61,7 +64,7 @@
 @media screen and (max-width:1079px) {
   .navbar-brand{
       margin-top: 2px;
-      width: 130px;
+      width: 120px;
   }
 }
 

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -35,7 +35,7 @@
 
 .container-fluid{
   position: relative;
-} 
+}
 
 .container-fluid ul{
   padding-top: 6px;
@@ -49,7 +49,7 @@
 }
 
 .container-fluid li a{
-  position: relative; 
+  position: relative;
   left: -25px;
 }
 
@@ -86,6 +86,7 @@
 
 .active_view {
   color: #4285f4 !important;
+  font-weight: 900 !important;
   border-bottom: 3px solid #4285f4;
 }
 
@@ -103,8 +104,8 @@ img.res-img {
 }
 
 #search-options {
-  margin-top: 2.2%;
-  margin-left: 9%;
+  margin-top: 0.5%;
+  margin-left: 8.5%;
 }
 
 #search-tools {
@@ -169,9 +170,9 @@ img.res-img {
        border: 0px ;
        font-size: 16px;
  }
- 
- .active_page{  
-       color: black; 
+
+ .active_page{
+       color: black;
  }
 
 .image-result {
@@ -190,7 +191,7 @@ img.res-img {
 
 @media screen and (max-width:1365px) {
   #tools {
-    margin-left: 21.5%;
+    margin-left: 16%;
   }
 }
 
@@ -199,13 +200,13 @@ img.res-img {
     margin-left: 11%;
   }
   #tools {
-    margin-left: 17%;
+    margin-left: 14%;
   }
 }
 
 @media screen and (max-width:991px) {
   #tools {
-    margin-left: 26%;
+    margin-left: 20%;
   }
 }
 
@@ -214,17 +215,17 @@ img.res-img {
     margin-left: 12.5%;
   }
   #tools {
-    margin-left: 18%;
+    margin-left: 19%;
   }
 }
 
 @media screen and (max-width:767px) {
   .result {
-    padding-left: 50px;
+    padding-left: 46px;
     padding-right: 30px;
   }
   #progress-bar {
-    padding-left: 50px;
+    padding-left: 46px;
     margin-bottom: -10px;
   }
   #search-options {
@@ -285,3 +286,8 @@ img.res-img {
     padding: 0px 5.6% 12px;
   }
 }
+
+p {
+  padding-right: 500px;
+}
+

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -2,7 +2,8 @@
   background-color: white;
   width: 584px;
   color: black;
-  height: 44px;
+  height: 8px;
+  top:3px;
   border-radius: 0px;
   border: none;
   border-style: solid;
@@ -34,12 +35,9 @@
   border: none;
 }
 
-#nav-group{
-  top:3px;
-}
-
 .navbar-form{
   border-color: transparent !important;
+  padding-left: .5%;
 }
 
 @media screen and (min-width:1920px) {


### PR DESCRIPTION
Fixes #184, Partially solves #232 
The susper search bar resembles that of google

- The active page is bolder
- Resized susper logo
- Resized search bar
- Removed the line between search bar and nav panel
- Aligned all the text to the new position of search bar
- Reduced the height of the header
Before: 
![image](https://cloud.githubusercontent.com/assets/20185076/25795872/ed7a953c-33f4-11e7-9c33-68f87d5f76ac.png)
Now:
![image](https://cloud.githubusercontent.com/assets/20185076/25795885/fc97b90a-33f4-11e7-8fa4-e61b5db9bb9c.png)
Target:
![image](https://cloud.githubusercontent.com/assets/20185076/25795897/09760b18-33f5-11e7-8402-8d1a485cf6e1.png)

I didnot add News, Settings etc, since susper still doesnot support the features in such menus and sub-menus of Google.
