### PR TITLE
Fixes #184, Search bar and header more like market leader

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -7,10 +7,14 @@
   width: 60px;
   height: 50px;
 }
+.navbar-default{
+  border-bottom: none;
+}
 
 .top-nav{
   margin-bottom: 0px;
   margin-top: -5%;
+  padding-top: 0.4%;
 }
 
 .menu-drop-image{
@@ -32,7 +36,7 @@
 }
 
 .dropdown-menu{
-  width: 100px;    
+  width: 100px;
 }
 
 #navcontainer ul {
@@ -43,7 +47,7 @@
 
 @media screen and (min-width:1920px) {
   .navbar-brand{
-      width: 170px;
+      width: 160px;
       height: auto;
   }
 }
@@ -61,7 +65,7 @@
 @media screen and (max-width:1079px) {
   .navbar-brand{
       margin-top: 2px;
-      width: 130px;
+      width: 120px;
   }
 }
 

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -96,6 +96,7 @@
 
 .active_view {
   color: #4285f4 !important;
+  font-weight: 900 !important;
   border-bottom: 3px solid #4285f4;
 }
 
@@ -113,8 +114,8 @@ img.res-img {
 }
 
 #search-options {
-  margin-top: 2.2%;
-  margin-left: 9%;
+  margin-top: 0.5%;
+  margin-left: 8.5%;
 }
 
 #search-tools {
@@ -204,7 +205,7 @@ img.res-img {
 
 @media screen and (max-width:1365px) {
   #tools {
-    margin-left: 21.5%;
+    margin-left: 16%;
   }
 }
 
@@ -213,13 +214,13 @@ img.res-img {
     margin-left: 11%;
   }
   #tools {
-    margin-left: 17%;
+    margin-left: 14%;
   }
 }
 
 @media screen and (max-width:991px) {
   #tools {
-    margin-left: 26%;
+    margin-left: 20%;
   }
 }
 
@@ -228,17 +229,17 @@ img.res-img {
     margin-left: 12.5%;
   }
   #tools {
-    margin-left: 18%;
+    margin-left: 19%;
   }
 }
 
 @media screen and (max-width:767px) {
   .result {
-    padding-left: 50px;
+    padding-left: 46px;
     padding-right: 30px;
   }
   #progress-bar {
-    padding-left: 50px;
+    padding-left: 46px;
     margin-bottom: -10px;
   }
   #search-options {
@@ -303,3 +304,4 @@ img.res-img {
 p {
   padding-right: 500px;
 }
+

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -2,7 +2,8 @@
   background-color: white;
   width: 584px;
   color: black;
-  height: 44px;
+  height: 8px;
+  top: 3px;
   border-radius: 0px;
   border: none;
   border-style: solid;
@@ -42,6 +43,7 @@
 
 .navbar-form{
   border-color: transparent !important;
+  padding-left: 0.5%;
 }
 
 @media screen and (min-width:1920px) {


### PR DESCRIPTION
Fixes #184, Partially solves #232 
The susper search bar resembles that of google

- The active page is bolder
- Resized susper logo
- Resized search bar
- Removed the line between search bar and nav panel
- Aligned all the text to the new position of search bar
- Reduced the height of the header
Before: 
![image](https://cloud.githubusercontent.com/assets/20185076/25795872/ed7a953c-33f4-11e7-9c33-68f87d5f76ac.png)
Now:
![image](https://cloud.githubusercontent.com/assets/20185076/25814002/6323f51e-3439-11e7-87a9-1275457d1c08.png)

Target:
![image](https://cloud.githubusercontent.com/assets/20185076/25795897/09760b18-33f5-11e7-8402-8d1a485cf6e1.png)

I didnot add News, Settings etc, since susper still doesnot support the features in such menus and sub-menus of Google.