### PR TITLE
Fixes #147 Implement Ligthbox for the images

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
+    "ngbox": "0.0.15",
     "protractor": "4.0.9",
     "ts-node": "1.2.1",
     "tslint": "^4.0.2",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
 <router-outlet></router-outlet>
+<ngbox></ngbox>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,8 @@ import { FooterNavbarComponent } from './footer-navbar/footer-navbar.component';
 import { ContactComponent } from './contact/contact.component';
 import { Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { TermsComponent } from './terms/terms.component';
+import { NgBoxModule } from 'ngbox/ngbox.module';
+import { NgBoxService } from 'ngbox/ngbox.service';
 
 const appRoutes: Routes = [
   {path: 'search', component: ResultsComponent},
@@ -53,10 +55,11 @@ const appRoutes: Routes = [
     RouterModule.forRoot(appRoutes),
     StoreModule.provideStore(reducer),
     StoreDevtoolsModule.instrumentOnlyWithExtension(),
-    Ng2Bs3ModalModule
+    Ng2Bs3ModalModule,
+    NgBoxModule
 
   ],
-  providers: [SearchService],
+  providers: [SearchService, NgBoxService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -39,7 +39,7 @@
         </div>
         <div class="image-result" *ngIf="Display('images')">
             <div *ngFor="let item of items$|async">
-                <img class="res-img" src="{{item.link}}" onerror="this.style.display='none'">
+                <a href="{{item.link}}" [image]="true" ng-box><img class="res-img" src="{{item.link}}" onerror="this.style.display='none'"></a>
             </div>
         </div>
         <div class="video-result" *ngIf="Display('videos')">


### PR DESCRIPTION
Resolves #147 

See : #159 

Previously I had some issues with that PR, due to which I was unable to resolve conflicts.

Things I have done in this PR : 
- Used an external package `ngbox` to implement the lightbox feature for the images section.

Problems I'm facing at present : 

- @nikhilrayaprolu We recently had a talk related to unit tests which has been written at present. Check Travis CI errors, when `ng test` runs. I'm unable to solve those errors. The only possible way to solve them is to import modules `NgBoxModule` and `NgBoxService` in each `.spec.ts` file. But this method increases the running time for travis.  

Screenshot : 

![screenshot from 2017-05-08 23-56-32](https://cloud.githubusercontent.com/assets/22245418/25818975/0e581aea-344a-11e7-8d91-e9aebc7d9ec4.png)
