### PR TITLE
Fixes #205 Add top menu links on right on contact and terms page

### DIFF
--- a/src/app/about/about.component.css
+++ b/src/app/about/about.component.css
@@ -40,6 +40,9 @@
     .banner {
         top: 0;
     }
+    .navbar-collapse.navbar-right {
+        text-align: right;
+    }
 }
 
 .about-navbar {

--- a/src/app/contact/contact.component.css
+++ b/src/app/contact/contact.component.css
@@ -1,3 +1,9 @@
+@media screen and (max-width:990px) {
+    .navbar-collapse.navbar-right {
+        text-align: right;
+    }
+}
+
 .banner {
     width: 100%;
     position: relative;
@@ -17,6 +23,7 @@
 .navbar-logo {
     height: 30px;
     padding-left: 20px;
+    margin-top: -4%;
 }
 
 .navbar-text {
@@ -117,4 +124,23 @@
     padding: 10px;
     position: relative;
     top:5px;
+}
+
+a {
+    text-decoration: none;
+    padding-right: 30px;
+    color: rgb(119,119,119);
+}
+
+.navbar-collapse.navbar-right {
+    padding-top: 15px;
+}
+
+a:hover {
+    color: rgb(51,51,51);
+    text-decoration: none;
+}
+
+.navbar-brand {
+    padding-left: 100px;
 }

--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -5,11 +5,15 @@
 <nav class="navbar navbar-default nav-about">
   <div class="container-fluid">
     <div class="navbar-header">
-      <a class="navbar-brand about-navbar" href="//susper.com">
+      <a class="navbar-brand contact-navbar" href="//susper.com">
         <img alt="brand" class="navbar-logo" src="../../assets/images/susper.svg">
       </a>
     </div>
-    <p class="navbar-text navbar-right">Contact Us</p>
+    <p class="navbar-collapse navbar-right">
+      <a routerLink="/terms">Terms</a>
+      <a routerLink="/about">About</a>
+      <a routerLink="/contact">Contact</a>
+    </p>
   </div>
 </nav>
 

--- a/src/app/terms/terms.component.css
+++ b/src/app/terms/terms.component.css
@@ -1,4 +1,8 @@
-
+@media screen and (max-width:990px) {
+	.navbar-collapse.navbar-right {
+		text-align: right;
+	}
+}
 
 .bold{
 	font-weight: 700;
@@ -63,4 +67,23 @@ h2{
 	#right{
 			width: 100%;
 	}
+}
+
+a {
+	text-decoration: none;
+	padding-right: 30px;
+	color: rgb(119,119,119);
+}
+
+.navbar-collapse.navbar-right {
+	padding-top: 15px;
+}
+
+a:hover {
+	color: rgb(51,51,51);
+	text-decoration: none;
+}
+
+.navbar-brand {
+	padding-left: 100px;
 }

--- a/src/app/terms/terms.component.html
+++ b/src/app/terms/terms.component.html
@@ -9,10 +9,13 @@
                 <img alt="brand" class="navbar-logo" src="../../assets/images/susper.svg">
             </a>
         </div>
-        <p class="navbar-text navbar-right">Terms Page</p>
+        <p class="navbar-collapse navbar-right">
+            <a routerLink="/terms">Terms</a>
+            <a routerLink="/about">About</a>
+            <a routerLink="/contact">Contact</a>
+        </p>
     </div>
 </nav>
-
 
 <div class="container">
     <div class="col-md-3">


### PR DESCRIPTION
Resolves #205 

Things I have done in this PR : 
- Added top menu links on top-right corner on contact and terms page.

Screenshots : 

Terms Page

![selection_003](https://cloud.githubusercontent.com/assets/22245418/25842071/48afe7ec-34c0-11e7-9bc7-07020022c592.png)

Contacts Page 

![selection_002](https://cloud.githubusercontent.com/assets/22245418/25842093/595b70b6-34c0-11e7-93c4-85e6d0ae2205.png)

