### PR TITLE
Fixes #238, Rectifies Search Bar Position

### DIFF
--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -43,7 +43,6 @@
 
 .navbar-form{
   border-color: transparent !important;
-  padding-left: 0.5%;
 }
 
 @media screen and (min-width:1920px) {


### PR DESCRIPTION
Fixes #238 , ![image](https://cloud.githubusercontent.com/assets/20185076/25849398/f87c8ade-34db-11e7-9cf2-4fb7a4e9acc8.png)
 Removed the extra padding specification, to avoid pushing the search bar to the next line.