### PR TITLE
Fixes #244 Footer-navbar position for results section

### DIFF
--- a/src/app/footer-navbar/footer-navbar.component.css
+++ b/src/app/footer-navbar/footer-navbar.component.css
@@ -7,7 +7,9 @@ footer {
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
-  margin-top: 100px;
+  margin-bottom: 0px;
+  position: fixed;
+  bottom: 0px;
 }
 
 div a {

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -161,6 +161,7 @@ img.res-img {
 
 .pagination-property {
   max-width: 100%;
+  padding-bottom: 30px;
 }
 
 .pagination li span


### PR DESCRIPTION
Resolves #244 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>.

Things I have done in this PR : 
- Fixed the footer-navbar position in results section under each tab - All, images and videos.

Screenshot : 

![selection_014](https://cloud.githubusercontent.com/assets/22245418/25871468/334a41f8-3525-11e7-8330-eb32779722ba.png)

Please check the preview link, to check the position of footer-navbar under 'images' and 'All' section. (if required) : )