### PR TITLE
Fixes #182 Logo and search bar are centered

### DIFF
--- a/src/app/index/index.component.css
+++ b/src/app/index/index.component.css
@@ -4,53 +4,13 @@
 
 #search-bar{
   position: absolute;
-  left: 27%;
+  left: 28%;
 }
+
 .footer-fixed{
   position: fixed;
   bottom: 0px;
   width: 100%;
-}
-@media screen and (min-width: 1920px) {
-  #search-bar{
-    left: 28%;
-  }
-}
-
-@media screen and (max-width: 11360px) {
-  #search-bar{
-    left: 24%;
-  }
-}
-
-@media screen and (max-width: 1040px) {
-  #search-bar{
-    left: 20%;
-  }
-}
-
-@media screen and (max-width: 908px) {
-  #search-bar{
-    left: 16%;
-  }
-}
-
-@media screen and (max-width: 753px) {
-  #search-bar{
-    left: 6%;
-  }
-}
-
-@media screen and (max-width: 479px) {
-  #search-bar{
-    left: 5%;
-  }
-}
-
-@media screen and (max-width: 359px) {
-  #search-bar{
-    left: 4%;
-  }
 }
 
 #set-susper-default{

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -84,3 +84,43 @@
     left: -5%;
   }
 }
+
+@media screen and (min-width: 1920px) {
+  #nav-group {
+    left: 65%;
+  }
+}
+
+@media screen and (max-width: 991px) {
+  #nav-group {
+    left: -12%;
+  }
+  #nav-input {
+    width: 50vw;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  #nav-group {
+    left: -22%;
+    width: 20px;
+  }
+  #nav-input {
+    width: 80vw;
+  }
+}
+
+@media screen and (max-width: 503px) {
+  #nav-group {
+    width: 5px;
+  }
+  #nav-input {
+    width: 80vw;
+  }
+}
+
+@media screen and (max-width: 359px) {
+  #nav-input {
+    width: 80vw;
+  }
+}


### PR DESCRIPTION
Resolves #182 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>.

Things I have done in this PR : 
- For the desktop view, logo and search bar are now centered.
- Upto screen size `655px` homepage is responsive. 

Screenshot - 

Desktop View : 

![selection_020](https://cloud.githubusercontent.com/assets/22245418/25875423/f74f467a-3534-11e7-8787-fae77f126143.png)

Upto `655px` homepage responsiveness : 

![selection_021](https://cloud.githubusercontent.com/assets/22245418/25875442/157442d6-3535-11e7-9516-ada791f66fef.png)
