### PR TITLE
Fixes #214, Install box overlap with search bar avoided for all screen sizes

### DIFF
--- a/src/app/index/index.component.css
+++ b/src/app/index/index.component.css
@@ -72,6 +72,60 @@
   }
 }
 
+@media screen and (max-width: 281px) {
+  #set-susper-default{
+    bottom: 80px;
+  }
+  #set-susper-default h3{
+    font-size: 14px;
+  }
+  #set-susper-default ol{
+    font-size: 12px;
+  }
+  #install-susper{
+    font-size: 12px;
+  }
+  #cancel-installation{
+    font-size: 12px;
+  }
+}
+
+@media screen and (max-height: 584px) {
+  #set-susper-default{
+    bottom: 75px;
+  }
+  #set-susper-default h3{
+    font-size: 14px;
+  }
+  #set-susper-default ol{
+    font-size: 12px;
+  }
+  #install-susper{
+    font-size: 12px;
+  }
+  #cancel-installation{
+    font-size: 12px;
+  }
+}
+
+@media screen and (max-height: 530px) {
+  #set-susper-default{
+    bottom: 75px;
+  }
+  #set-susper-default h3{
+    font-size: 12px;
+  }
+  #set-susper-default ol{
+    font-size: 10px;
+  }
+  #install-susper{
+    font-size: 10px;
+  }
+  #cancel-installation{
+    font-size: 10px;
+  }
+}
+
 .navbar-fixed-bottom{
   z-index: -1;
 }


### PR DESCRIPTION
Fixes #214,

Description:Changes box size and position at different widths and heights to prevent overlap, with the footer and the search bar 

Sample Screenshots:
![image](https://cloud.githubusercontent.com/assets/20185076/25885882/a16cecc8-3578-11e7-909c-ee7b3176abc4.png)
![image](https://cloud.githubusercontent.com/assets/20185076/25885921/c05fd9c4-3578-11e7-957c-16e1bd608252.png)
![image](https://cloud.githubusercontent.com/assets/20185076/25885945/d4125550-3578-11e7-92fa-82cd6493dfec.png)

Test link - [here](https://marauderer97.github.io/susper.com/)
