### PR TITLE
Fixes #252, Images are now clickable

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -36,7 +36,7 @@
         </div>
         <div class="image-result" *ngIf="Display('images')">
             <div *ngFor="let item of items$|async">
-                <img class="res-img" src="{{item.link}}" onerror="this.style.display='none'">
+              <a href="{{item.link}}"><img class="res-img" src="{{item.link}}" onerror="this.style.display='none'"></a>
             </div>
         </div>
         <div class="video-result" *ngIf="Display('videos')">


### PR DESCRIPTION
Fixes #252,

Description: Clicking on images, opens their links now.

Screenshots: 
![image](https://cloud.githubusercontent.com/assets/20185076/25898168/906159a2-35a8-11e7-86a2-5215e957720d.png)
![image](https://cloud.githubusercontent.com/assets/20185076/25898180/9cc6e07c-35a8-11e7-85da-07baab1b4228.png)

Demo link : [Here](https://marauderer97.github.io/susper.com/)