### PR TITLE
Fixes #258, Prevents search bar overlap with logo

### DIFF
--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -56,7 +56,7 @@
 
 @media screen and (max-width: 979px) and (min-width: 768px) {
   .navbar-form{
-    padding-left: 5px;
+    padding-left: 84px;
    }
 }
 


### PR DESCRIPTION
Fixes #258 
Prevented search bar overlap with logo
Screenshot:
![image](https://cloud.githubusercontent.com/assets/20185076/25910136/fb3b110e-35cc-11e7-9244-e17774184b81.png)
Test link:[Here](https://marauderer97.github.io/susper.com/)