### PR TITLE
Fixes #257 Match the position of Tools following the market leader

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -55,7 +55,9 @@
       width: 160px;
       height: auto;
   }
-<<<<<<< HEAD
+  .top-nav {
+    margin-top: -5%;
+  }
 }
 
 @media screen and (min-width:768px) {
@@ -69,10 +71,6 @@
   }
   #navcontainer, #side-menu {
     margin-top: 8px;
-=======
-  .top-nav{
-    margin-top: -5%;
->>>>>>> upstream/master
   }
 }
 

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -39,6 +39,11 @@
   width: 100px;
 }
 
+.dropdown {
+  position: relative;
+  margin-left: -10px;
+}
+
 #navcontainer ul {
   margin: 0;
   padding: 0;
@@ -103,11 +108,17 @@
     margin-right: 1% !important;
   }
 }
+
 @media screen and (min-width:768px) {
   #navcontainer ul li {
     display: inline;
   }
-
+  .navbar-right {
+    padding-right: 20px;
+    font-size: 14px;
+    left: 95%;
+    position: absolute;
+  }
   #navcontainer, #side-menu {
     margin-top: 8px;
   }

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -56,7 +56,11 @@
   #navcontainer ul li {
     display: inline;
   }
-
+  .navbar-right {
+    padding-right: 20px;
+    font-size: 14px;
+    left: 92%;
+  }
   #navcontainer, #side-menu {
     margin-top: 8px;
   }
@@ -75,7 +79,7 @@
       height: auto;
   }
   #navbar-search {
-    margin-left: 7%;
+    margin-left: 21%;
     margin-right: 8%;
   }
   .align-navsearch-btn {
@@ -94,7 +98,7 @@
       margin-left: 33%;
   }
   #navbar-search {
-    margin-left: 5%;
+    margin-left: 20%;
     margin-right: 9%;
   }
   .align-navsearch-btn {

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -216,15 +216,12 @@ img.res-img {
   }
   #tools {
     margin-left: 17%;
-<<<<<<< HEAD
-=======
   }
 }
 
 @media screen and (max-width:1105px) {
   #tools {
     margin-left: 18%;
->>>>>>> a756c96... Fix 'tools' responsiveness
   }
 }
 
@@ -238,12 +235,6 @@ img.res-img {
   #search-options {
     margin-left: 12.5%;
   }
-<<<<<<< HEAD
-  #tools {
-    margin-left: 22%;
-  }
-=======
->>>>>>> a756c96... Fix 'tools' responsiveness
 }
 
 @media screen and (max-width:767px) {
@@ -270,15 +261,12 @@ img.res-img {
   }
   #tools {
     margin-left: -19%;
-<<<<<<< HEAD
-=======
   }
 }
 
 @media screen and (max-width:741px) {
   #tools {
     margin-left: -26%;
->>>>>>> a756c96... Fix 'tools' responsiveness
   }
 }
 

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -150,7 +150,7 @@ img.res-img {
 #tools {
   text-decoration: none;
   color: #777;
-  margin-left: 27%;
+  margin-left: 15%;
 }
 
 #tools:hover {
@@ -215,7 +215,7 @@ img.res-img {
     margin-left: 11%;
   }
   #tools {
-    margin-left: 14%;
+    margin-left: 17%;
   }
 }
 
@@ -230,7 +230,7 @@ img.res-img {
     margin-left: 12.5%;
   }
   #tools {
-    margin-left: 19%;
+    margin-left: 22%;
   }
 }
 
@@ -245,7 +245,6 @@ img.res-img {
   }
   #search-options {
     padding-left: 0px;
-    margin-top: 75px;
     margin-left: 8%;
   }
   #pag-bar {
@@ -258,7 +257,7 @@ img.res-img {
     padding: 0px 8.3% 12px;
   }
   #tools {
-    margin-left: 0%;
+    margin-left: -19%;
   }
 }
 
@@ -293,6 +292,12 @@ img.res-img {
 @media screen and (max-width:379px) {
   #search-options li {
     padding: 0px 6.2% 12px;
+  }
+}
+
+@media screen and (max-width:408px) {
+  #tools {
+    left: 20%;
   }
 }
 

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -216,6 +216,15 @@ img.res-img {
   }
   #tools {
     margin-left: 17%;
+<<<<<<< HEAD
+=======
+  }
+}
+
+@media screen and (max-width:1105px) {
+  #tools {
+    margin-left: 18%;
+>>>>>>> a756c96... Fix 'tools' responsiveness
   }
 }
 
@@ -229,9 +238,12 @@ img.res-img {
   #search-options {
     margin-left: 12.5%;
   }
+<<<<<<< HEAD
   #tools {
     margin-left: 22%;
   }
+=======
+>>>>>>> a756c96... Fix 'tools' responsiveness
 }
 
 @media screen and (max-width:767px) {
@@ -258,6 +270,15 @@ img.res-img {
   }
   #tools {
     margin-left: -19%;
+<<<<<<< HEAD
+=======
+  }
+}
+
+@media screen and (max-width:741px) {
+  #tools {
+    margin-left: -26%;
+>>>>>>> a756c96... Fix 'tools' responsiveness
   }
 }
 

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -56,7 +56,8 @@
 
 @media screen and (max-width: 979px) and (min-width: 768px) {
   .navbar-form{
-    padding-left: 84px;
+    padding-left: 4px;
+    width: 100px;
    }
 }
 
@@ -93,7 +94,7 @@
   }
 }
 
-@media screen and (max-width: 991px) {
+@media screen and (max-width: 968px) {
   #nav-group {
     left: -12%;
   }

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -56,7 +56,7 @@
 
 @media screen and (max-width: 979px) and (min-width: 768px) {
   .navbar-form{
-    padding-left: 5px;
+    padding-left: 84px;
    }
 }
 


### PR DESCRIPTION
Resolves #257 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>.

Things I have done in this PR : 
- Corrected the position of `tools` following the market leader.

Screenshots : 

![selection_038](https://cloud.githubusercontent.com/assets/22245418/25913079/1ed6ee6c-35d7-11e7-8fdf-907539e6a944.png)
