### PR TITLE
Revert "Fixes #244 Footer-navbar position for results section"

### DIFF
--- a/src/app/footer-navbar/footer-navbar.component.css
+++ b/src/app/footer-navbar/footer-navbar.component.css
@@ -8,8 +8,6 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0px;
-  position: fixed;
-  bottom: 0px;
 }
 
 div a {

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -176,7 +176,6 @@ img.res-img {
 
 .pagination-property {
   max-width: 100%;
-  padding-bottom: 30px;
 }
 
 .pagination li span


### PR DESCRIPTION
Reverts fossasia/susper.com#246

as the above merge is a bad practice in the component based architecture. reverting it.
Explanation:-
The position attributes should be independent of the child component I inherit, they should depend only on parent component. when I use the same component in other parent components, I should not have any internal css factors of the child component affecting the position in the parent component, there should be independency to apply my own css  in each parent component I inherit this. so where ever you want to fix the component as fixed , write this css only in the parent component but not in the child component, such that we could have other positions defined in other parent components.