### PR TITLE
Fixes #260, Top navigation bar, sticks to the top of the screen without white space

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -50,15 +50,8 @@
       width: 160px;
       height: auto;
   }
-}
-
-@media screen and (min-width:768px) {
-  #navcontainer ul li {
-    display: inline;
-  }
-
-  #navcontainer, #side-menu {
-    margin-top: 8px;
+  .top-nav{
+    margin-top: -5%;
   }
 }
 
@@ -67,9 +60,21 @@
       margin-top: 2px;
       width: 120px;
   }
+  .top-nav{
+    margin-top: -6%;
+  }
 }
 
-@media screen and (max-width:767px) {
+@media screen and (max-width:850px) {
+  .top-nav{
+    margin-top: -7%;
+  }
+}
+
+@media screen and (max-width:768px) {
+  .top-nav{
+    margin-top: -8%;
+  }
   .navbar-brand{
       margin-left: 38%;
       height: auto;
@@ -82,10 +87,21 @@
     margin-right: 1% !important;
   }
 }
+@media screen and (min-width:768px) {
+  #navcontainer ul li {
+    display: inline;
+  }
 
+  #navcontainer, #side-menu {
+    margin-top: 8px;
+  }
+}
 @media screen and (max-width:639px) {
   .align-navsearch-btn {
     margin-right: 2% !important;
+  }
+  .top-nav{
+    margin-top: -9%;
   }
 }
 
@@ -104,7 +120,7 @@
 
 @media screen and (max-width:359px) {
   .navbar-brand{
-      margin-left: 30%;
+    margin-left: 30%;
   }
 }
 


### PR DESCRIPTION
Fixes #260, 
Top navigation bar, sticks to the top of the screen without white space at different screen sizes.

Screenshots
![image](https://cloud.githubusercontent.com/assets/20185076/25942441/7d1acc7c-365a-11e7-9a2a-bc7f4b900224.png)

![image](https://cloud.githubusercontent.com/assets/20185076/25942459/88f247fa-365a-11e7-994e-aaa7ee0484f5.png)

![image](https://cloud.githubusercontent.com/assets/20185076/25942476/9453a026-365a-11e7-94f7-d56ad5b7fb8d.png)

![image](https://cloud.githubusercontent.com/assets/20185076/25942501/a109abd0-365a-11e7-9023-afa1f3f61a7e.png)

![image](https://cloud.githubusercontent.com/assets/20185076/25942514/ac52eeac-365a-11e7-9294-2182243353cb.png)

Test link - [Here](https://marauderer97.github.io/susper.com/)