### PR TITLE
Fixes #261 Alignment of rendered images

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -100,13 +100,32 @@
   border-bottom: 3px solid #4285f4;
 }
 
-img.res-img {
-  max-width: 350px;
-  max-height: 300px;
+/** Rendered image properties **/
+.container {
+  width: 100%;
+  margin: 0;
+  top: 0;
+  bottom: 0;
+  padding: 0;
+}
+
+.grid {
+  padding-left: 80px;
+}
+
+.responsive-image {
+  max-width: 100%;
+  height: 200px;
   padding-top: 20px;
   padding: 0.6%;
+  display: inline-block;
   float: left;
 }
+
+.image-pointer {
+  cursor: pointer;
+}
+/** END **/
 
 #search-options-field {
   background-color: #f8f8f8;
@@ -189,10 +208,6 @@ img.res-img {
  .active_page{
        color: black;
  }
-
-.image-result {
-  padding-left: 80px;
-}
 
 .clean {
   clear: both;

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -21,6 +21,8 @@
         <div class="container-fluid" id="progress-bar">
             {{message}}
         </div>
+    </div>
+    <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
         <div class="text-result" *ngIf="Display('all')">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
@@ -34,18 +36,25 @@
                 </div>
             </div>
         </div>
-        <div class="image-result" *ngIf="Display('images')">
-            <div *ngFor="let item of items$|async">
-              <a href="{{item.link}}"><img class="res-img" src="{{item.link}}" onerror="this.style.display='none'"></a>
+    </div>
+    <!-- Image section -->
+    <div class="container">
+        <div class="grid" *ngIf="Display('images')">
+            <div class="cell" *ngFor="let item of items$|async">
+                <a class="image-pointer" href="{{item.link}}"><img class="responsive-image" src="{{item.link}}"></a>
             </div>
         </div>
+    </div>
+    <!-- END -->
         <div class="video-result" *ngIf="Display('videos')">
-            <div *ngFor="let item of items$|async" class="result">
-                <div class="title">
-                    <a href="{{item.path}}">{{item.title}}</a>
-                </div>
-                <div class="link">
-                    <p>{{item.link}}</p>
+            <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+                <div *ngFor="let item of items$|async" class="result">
+                    <div class="title">
+                        <a href="{{item.path}}">{{item.title}}</a>
+                    </div>
+                    <div class="link">
+                        <p>{{item.link}}</p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -53,6 +62,7 @@
         <div class="clean"></div>
         <div class="pagination-property">
             <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
+                <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
                 <ul class="pagination" id="pag-bar">
                     <li class="page-item"><span class="page-link" href="#" (click)="decPresentPage()">Previous</span></li>
                     <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link" *ngIf="presentPage>=4 && num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
@@ -61,14 +71,13 @@
                             href="#">{{num+1}}</span></li>
                     <li class="page-item"><span class="page-link" (click)="incPresentPage()">Next</span></li>
                 </ul>
+                </div>
             </nav>
         </div>
     </div>
-</div>
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <app-advancedsearch></app-advancedsearch>
 </div>
 
 <!--footer navigation bar goes here-->
 <app-footer-navbar></app-footer-navbar>
-


### PR DESCRIPTION
Resolves #261 

Previously had some problems with merge conflicts due to which not able squash commits. See #263 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>.

Things I have done in this PR : 
- I have scaled the images to a common height maintaining their ratio as well.

Screenshot : 

![selection_047](https://cloud.githubusercontent.com/assets/22245418/25982504/abae8f56-36fa-11e7-9a3c-6e74db652466.png)

Problems : 
- Due to broken link of the images, a lot of white space is being left. See issue #108 , previously I did some work on it. But looks like it not working as we want.

What it looks like : 

![selection_046](https://cloud.githubusercontent.com/assets/22245418/25982555/1d0710c4-36fb-11e7-875c-90af6d376625.png)

What is happening actually : 

![selection_048](https://cloud.githubusercontent.com/assets/22245418/25982565/2df1c91a-36fb-11e7-9891-034c40ba14ac.png)


 