### PR TITLE
Fixes #268, Rendered images cover the white space on the sides

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -21,7 +21,9 @@
         <div class="container-fluid" id="progress-bar">
             {{message}}
         </div>
-        <div class="text-result" *ngIf="Display('all')">
+    </div>
+  <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+  <div class="text-result" *ngIf="Display('all')">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
                     <a href="{{item.link}}">{{item.title}}</a>
@@ -34,13 +36,15 @@
                 </div>
             </div>
         </div>
+  </div>
         <div class="image-result" *ngIf="Display('images')">
             <div *ngFor="let item of items$|async">
               <a href="{{item.link}}"><img class="res-img" src="{{item.link}}" onerror="this.style.display='none'"></a>
             </div>
         </div>
         <div class="video-result" *ngIf="Display('videos')">
-            <div *ngFor="let item of items$|async" class="result">
+          <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+          <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
                     <a href="{{item.path}}">{{item.title}}</a>
                 </div>
@@ -48,12 +52,14 @@
                     <p>{{item.link}}</p>
                 </div>
             </div>
+          </div>
         </div>
         <br>
         <div class="clean"></div>
         <div class="pagination-property">
             <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
-                <ul class="pagination" id="pag-bar">
+              <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+              <ul class="pagination" id="pag-bar">
                     <li class="page-item"><span class="page-link" href="#" (click)="decPresentPage()">Previous</span></li>
                     <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link" *ngIf="presentPage>=4 && num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
                             (click)="getPresentPage(presentPage-3+num)" href="#">{{presentPage-3+num}}</span>
@@ -61,10 +67,10 @@
                             href="#">{{num+1}}</span></li>
                     <li class="page-item"><span class="page-link" (click)="incPresentPage()">Next</span></li>
                 </ul>
+              </div>
             </nav>
         </div>
     </div>
-</div>
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <app-advancedsearch></app-advancedsearch>
 </div>


### PR DESCRIPTION
Fixes #268,
 Rendered images cover the white space on the sides, no margin is left on the left or right, as seen in the screenshot.

BEFORE:
![image](https://cloud.githubusercontent.com/assets/20185076/25994266/e24172c4-372a-11e7-8654-3bdbe9b7d91a.png)

NOW: 
![image](https://cloud.githubusercontent.com/assets/20185076/25994245/cbfe919a-372a-11e7-903f-45b290505f41.png)

Preview link - [Here](https://marauderer97.github.io/susper.com/)