### PR TITLE
Fixes #272, Makes About, Contact and Terms page more responsive

### DIFF
--- a/src/app/about/about.component.css
+++ b/src/app/about/about.component.css
@@ -136,3 +136,8 @@ a:hover {
 .navbar-brand {
     padding-left: 100px;
 }
+@media only screen and (max-width: 768px) {
+  .navbar-logo{
+    margin-left: -77px;
+  }
+}

--- a/src/app/contact/contact.component.css
+++ b/src/app/contact/contact.component.css
@@ -151,3 +151,9 @@ a:hover {
 .navbar-brand {
     padding-left: 100px;
 }
+
+@media only screen and (max-width: 768px) {
+  .navbar-logo{
+    margin-left: -77px;
+  }
+}

--- a/src/app/terms/terms.component.css
+++ b/src/app/terms/terms.component.css
@@ -29,6 +29,9 @@
     padding-left: 20px;
 }
 
+.about-navbar{
+
+}
 .navbar-text {
     padding-right: 30px;
     font-size: 20px;
@@ -43,7 +46,7 @@
 .link{
 	margin-top:2px;
 	font-weight: 700;
-	line-height: 1.8;
+	line-height: 1.1;
 	color:#1565C0;
 	text-decoration: none !important;
 
@@ -66,7 +69,8 @@ p{
 h2{
 	line-height: 1.8;
 }
-@media only screen and (max-width: 500px) {
+
+@media only screen and (max-width: 768px) {
 	#left{
 			width: 100%;
 	}
@@ -74,6 +78,14 @@ h2{
 	#right{
 			width: 100%;
 	}
+  .navbar-brand{
+    margin-left: -77px;
+  }
+}
+@media only screen and (max-width: 923px)and (min-width: 768px) {
+  .navbar-brand{
+    margin-left: -27%!important;
+  }
 }
 
 a {
@@ -94,3 +106,8 @@ a:hover {
 .navbar-brand {
 	padding-left: 100px;
 }
+
+
+
+
+

--- a/src/app/terms/terms.component.html
+++ b/src/app/terms/terms.component.html
@@ -26,11 +26,11 @@
 </nav>
 
 <div class="container">
-    <div class="col-md-3">
+    <div id="left" class="col-lg-4 col-md-3 col-sm-12">
         <br><br><br>
         <h4 style="color:blue;" class="link">Terms of Service</h4>
     </div>
-    <div class="col-md-9">
+    <div id = "right"class ="col-lg-8 col-md-9 col-sm-12">
         <br><br>
         <h2>Welcome to susper!</h2>
         <p>Thanks for using our products and services (“Services”). The Services are provided by FOSSASIA community, located


### PR DESCRIPTION
Fixes #272,
 Description: Makes About, Contact and Terms page more responsive. Uses bootstrap classes, along with css for more responsive pages, particularly for Terms

Screenshots:
![image](https://cloud.githubusercontent.com/assets/20185076/26001574/6dee67f4-374a-11e7-9e3b-05cc3a27fa9d.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26001587/791738c2-374a-11e7-8c8b-bd37f5c9340b.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26001600/84f14e62-374a-11e7-9a7c-62dc740661ba.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26001617/9503005c-374a-11e7-8757-583180356d02.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26001625/9f38f64e-374a-11e7-80d3-314eb43b5ad1.png)

![image](https://cloud.githubusercontent.com/assets/20185076/26001542/564a5cde-374a-11e7-87e3-0c6a2ab8b586.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26001552/5f942838-374a-11e7-82d4-74d3e391c141.png)

Preview link - [here](https://marauderer97.github.io/susper.com/)