### PR TITLE
Fixes  #244 Fix the footer-navbar for the results section.

### DIFF
--- a/src/app/reducers/search.ts
+++ b/src/app/reducers/search.ts
@@ -29,7 +29,7 @@ export function reducer(state: State = initialState, action: search.Actions): St
       return Object.assign({}, state, {
         searchresults: search,
         items: search.channels[0].items,
-        totalResults: Number(search.channels[0].totalResults),
+        totalResults: Number(search.channels[0].totalResults) || 0,
         navigation: search.channels[0].navigation,
       });
     }

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -76,5 +76,5 @@
 </div>
 
 <!--footer navigation bar goes here-->
-<app-footer-navbar></app-footer-navbar>
+<app-footer-navbar [hidden]="hidefooter"></app-footer-navbar>
 

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -35,6 +35,7 @@ export class ResultsComponent implements OnInit {
     timezoneOffset: 0,
   };
   querylook = {};
+  hidefooter = 1;
   getNumber(N) {
     let result = Array.apply(null, { length: N }).map(Number.call, Number);
     if (result.length > 10) {
@@ -107,6 +108,8 @@ export class ResultsComponent implements OnInit {
     private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
 
     this.activatedroute.queryParams.subscribe(query => {
+      this.hidefooter = 1;
+
       if (query['fq']) {
 
         if (query['fq'].includes('png')) {
@@ -119,6 +122,7 @@ export class ResultsComponent implements OnInit {
       } else {
         this.resultDisplay = 'all';
       }
+
 
       this.presentPage = query['start'] / this.searchdata.rows;
       this.searchdata.query = query['query'];
@@ -133,13 +137,19 @@ export class ResultsComponent implements OnInit {
       this.store.dispatch(new queryactions.QueryServerAction(query));
       this.items$ = store.select(fromRoot.getItems);
       this.totalResults$ = store.select(fromRoot.getTotalResults);
-      this.totalResults$.subscribe(totalResults => {
-        this.end = Math.min(totalResults, this.begin + this.searchdata.rows - 1);
-        this.message = 'showing results ' + this.begin + ' to ' + this.end + ' of ' + totalResults;
-        this.noOfPages = Math.ceil(totalResults / this.searchdata.rows);
-        this.maxPage = Math.min(this.searchdata.rows, this.noOfPages);
-      });
 
+
+
+    });
+    this.totalResults$.subscribe(totalResults => {
+      if (totalResults) {
+        this.hidefooter = 0;
+
+      }
+      this.end = Math.min(totalResults, this.begin + this.searchdata.rows - 1);
+      this.message = 'showing results ' + this.begin + ' to ' + this.end + ' of ' + totalResults;
+      this.noOfPages = Math.ceil(totalResults / this.searchdata.rows);
+      this.maxPage = Math.min(this.searchdata.rows, this.noOfPages);
     });
 
     this.presentPage = 0;


### PR DESCRIPTION
Whenever the results are less in number, the footer moves away from its position and leaves the space at bottom of the page.completely hided the footer when no results are shown,similar to google instant search.

![image](https://cloud.githubusercontent.com/assets/15216503/26010375/4a741fd8-376a-11e7-95f9-b09a87914065.png)

![image](https://cloud.githubusercontent.com/assets/15216503/26010409/651ec1d0-376a-11e7-8df1-ccd46ed1c950.png)

previewlink : https://susper-pr-278.herokuapp.com/