### PR TITLE
Fixes #281, Minimum height of the body is fixed, to push footer down

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -3,6 +3,9 @@
   padding-top: 18px;
 }
 
+.row{
+  min-height: 84vh;
+}
 .title >a {
   color: #1a0dab;
   font-size: large;


### PR DESCRIPTION
Fixes #281,
 Minimum height of the body is fixed, to push footer down when content is too less.
Screenshots: 
Before:
![image](https://cloud.githubusercontent.com/assets/20185076/26027679/c7af326a-382f-11e7-8df6-67933c7df866.png)
Now:
![image](https://cloud.githubusercontent.com/assets/20185076/26027683/d18d5d48-382f-11e7-8484-59a51816824b.png)
(Responsive)
![image](https://cloud.githubusercontent.com/assets/20185076/26027687/e7776072-382f-11e7-89ce-fccce039503b.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26027695/167b4aaa-3830-11e7-8914-69bde1887069.png)

Preview link - [Here](https://marauderer97.github.io/susper.com/)