### PR TITLE
Fixes #280 Align link titles in results page

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -1,15 +1,14 @@
+/** Basic results 'All' **/
 .result {
-  padding-left: 60px;
-  padding-top: 18px;
+  padding-left: 50px;
+  padding-top: 10px;
 }
 
-.title >a {
-  color: #1a0dab;
+.title {
   font-size: large;
   text-decoration: none;
-  font-family: Arial, sans-serif;
   white-space: nowrap;
-  overflow: hidden;
+  overflow: hidden !important;
   text-overflow: ellipsis;
 }
 
@@ -20,10 +19,14 @@
   font-size: 14px;
   font-style: normal;
   font-family: Arial, sans-serif;
+  text-overflow: ellipsis;
+  overflow: hidden !important;
+  white-space: nowrap;
+  line-height: 1.2;
 }
 
-.title >a:hover {
-  text-decoration: underline;
+a {
+  text-decoration: none;
 }
 
 .description {
@@ -31,7 +34,32 @@
   color: #808080;
   line-height: 1.4;
   word-wrap: break-word;
+  margin-top: -8px;
 }
+
+.feed {
+  width: 670px;
+}
+
+.title-pointer:hover {
+  text-decoration: underline;
+}
+
+.title-pointer {
+  text-overflow: ellipsis;
+  overflow: hidden !important;
+  white-space: nowrap;
+  color: #1a0dab;
+  font-family: Arial, sans-serif;
+}
+/** END **/
+/** Screen responsiveness for result feed **/
+@media screen and (max-width:571px) {
+  .feed {
+    max-width: 100%;
+  }
+}
+/** END **/
 
 .page-link {
   cursor: pointer;
@@ -301,8 +329,3 @@ img.res-img {
     padding: 0px 5.6% 12px;
   }
 }
-
-p {
-  padding-right: 500px;
-}
-

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -22,11 +22,12 @@
             {{message}}
         </div>
     </div>
-  <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
-  <div class="text-result" *ngIf="Display('all')">
+    <!-- Basic results 'All' -->
+    <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+        <div class="text-result" *ngIf="Display('all')">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
-                    <a href="{{item.link}}">{{item.title}}</a>
+                    <a class="title-pointer" href="{{item.link}}">{{item.title}}</a>
                 </div>
                 <div class="link">
                     <p>{{item.link}}</p>
@@ -36,17 +37,18 @@
                 </div>
             </div>
         </div>
-  </div>
+    </div>
+    <!-- END -->
         <div class="image-result" *ngIf="Display('images')">
             <div *ngFor="let item of items$|async">
               <a href="{{item.link}}"><img class="res-img" src="{{item.link}}" onerror="this.style.display='none'"></a>
             </div>
         </div>
         <div class="video-result" *ngIf="Display('videos')">
-          <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
-          <div *ngFor="let item of items$|async" class="result">
+          <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+            <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
-                    <a href="{{item.path}}">{{item.title}}</a>
+                    <a class="title-pointer" href="{{item.path}}">{{item.title}}</a>
                 </div>
                 <div class="link">
                     <p>{{item.link}}</p>


### PR DESCRIPTION
Resolves #280 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>

Things I have done in this PR : 
- I have aligned the link titles in results page, followed with 3 dots `...`

Screenshots : 

Before -
![selection_051](https://cloud.githubusercontent.com/assets/22245418/26029063/10f4b8fe-384a-11e7-8432-f344ce2c4e81.png)

After -
![selection_050](https://cloud.githubusercontent.com/assets/22245418/26029066/16e7d714-384a-11e7-8080-edb1b50d4856.png)

