### PR TITLE
Fixes #284, Updates links in menu

### DIFF
--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -45,6 +45,18 @@
                                 </a>
                                 <p class="header-text">Bug Reports</p>
                             </div>
+                          <div class="header" id="header-contact">
+                            <a routerLink="/contact" routerLinkActive="active">
+                              <i class="fa fa-phone" aria-hidden="true" style="font-size: 2em" id="contact-icon"></i>
+                            </a>
+                            <p class="header-text">Contact</p>
+                          </div>
+                          <div class="header" id="header-search">
+                            <a routerLink="/advancedsearch" routerLinkActive="active">
+                              <i class="fa fa-search" aria-hidden="true" style="font-size: 2em" id="search-icon"></i>
+                            </a>
+                            <p class="header-text">Advanced Search</p>
+                          </div>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
Fixes #284,
 Updates links in menu, adds links to advanced search and contact too. I have not removed the link to Github, though it is the same as code, because if the code link just refers to code, but the github link can be used to view the community in general.
![image](https://cloud.githubusercontent.com/assets/20185076/26033933/5093efb0-38d2-11e7-8630-e364f8523e71.png)
Demo link - [here](https://marauderer97.github.io/susper.com/)