### PR TITLE
Fixes #286, Top nav bar in advanced search resembles other pages

### DIFF
--- a/src/app/newadvancedsearch/newadvancedsearch.component.css
+++ b/src/app/newadvancedsearch/newadvancedsearch.component.css
@@ -1,4 +1,15 @@
+@media screen and (max-width:990px) {
+  .navbar-collapse.navbar-right {
+    text-align: right;
+  }
+}
+.navbar-nav > li > a{
+  text-align: left;
+}
 
+.navbar-right{
+  border-top:none;
+}
 
 .bold{
   font-weight: 700;
@@ -8,6 +19,28 @@
   padding: 0px;
   clear: both;
   margin: -57px 0 0 0
+}
+.advsearch-navbar{
+  position: relative;
+  top:-5px;
+}
+
+.navbar {
+  margin-bottom: 0px !important;
+}
+
+.nav-about {
+  clear: both;
+  margin: -57px 0 0 0
+}
+
+.navbar-logo {
+  height: 30px;
+  padding-left: 20px;
+  margin-top: -4%;
+}
+.navbar-brand{
+  margin-left: 25px!important;
 }
 label {
   font-weight: normal !important;
@@ -75,5 +108,10 @@ div{
 
   #right{
     width: 100%;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .navbar-logo{
+    margin-left: -77px;
   }
 }

--- a/src/app/newadvancedsearch/newadvancedsearch.component.html
+++ b/src/app/newadvancedsearch/newadvancedsearch.component.html
@@ -2,16 +2,29 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 <link href="https://fonts.googleapis.com/css?family=Quicksand" rel="stylesheet">
 <!-- Stop ignoring BootLintBear-->
-<nav class="navbar navbar-default nav-terms">
+<nav class="navbar navbar-default nav-about">
   <div class="container-fluid">
     <div class="navbar-header">
-      <a class="navbar-brand about-navbar" href="//susper.com">
+      <button type = "button" class = "navbar-toggle"
+              data-toggle = "collapse" data-target = "#dropmenu">
+        <span class = "icon-bar"></span>
+        <span class = "icon-bar"></span>
+        <span class = "icon-bar"></span>
+      </button>
+      <a class="navbar-brand advsearch-navbar" href="//susper.com">
         <img alt="brand" class="navbar-logo" src="../../assets/images/susper.svg">
       </a>
     </div>
-
+    <div class="collapse navbar-collapse" id="dropmenu">
+      <ul class="nav navbar-nav navbar-collapse navbar-right">
+        <li><a routerLink="/terms">Terms</a></li>
+        <li><a routerLink="/about">About</a></li>
+        <li><a routerLink="/contact">Contact</a></li>
+      </ul>
+    </div>
   </div>
 </nav>
+
 
 
 <div class="container">


### PR DESCRIPTION
Fixes #286,
 Top nav bar in advanced search resembles other pages such as Contact, Terms and About.
Screenshots:
![image](https://cloud.githubusercontent.com/assets/20185076/26050998/6d5205f4-397e-11e7-89eb-dff925553900.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26050985/5f8bd85a-397e-11e7-8fb6-372a0330e0d8.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26051016/7ed0b53c-397e-11e7-8f49-4890b3523be1.png)

Preview link- [Here](https://marauderer97.github.io/susper.com/)

