### PR TITLE
Changes codecov, to remove Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,22 @@ before_install:
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-- docker build -t ci-build .
+
+before_script:
+  - ng build --prod
+
 script:
-- >
-  docker run --rm -v $(pwd):/usr/src/app ci-build
-- >
-  docker run -ti -v $(pwd):/app --workdir=/app coala/base coala --version
+  - ng test --watch=false
+  - ng lint
+
 after_success:
-- bash ./deploy.sh
 - bash <(curl -s https://codecov.io/bash)
+- bash ./deploy.sh
 cache:
     bundler: true
     directories:
     - node_modules
-    - .coala-cache
-services: docker
+
 branches:
    only:
    - master

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  branch: gh-pages1
+  branch: gh-pages
   bot: null
 
 coverage:


### PR DESCRIPTION
Refer to #161, #250 
Please donot merge as yet, 
Need to make sure travis first runs without failing,
This PR attempts to provide the repo with a code coverage by temporarily removing Docker, to first let codecov work without it.