### PR TITLE
Fixes #293, Info-box Position 

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -16,6 +16,7 @@
   text-overflow: ellipsis;
 }
 .infobox {
+  float:right!important;
 
 }
 

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -39,7 +39,7 @@
         </div>
     </div>
 
-  <app-infobox [hidden]="hidefooter" class="infobox col-md-4 col-md-offset-1"></app-infobox>
+  <app-infobox [hidden]="hidefooter" class="infobox col-md-4" *ngIf="Display('all')"></app-infobox>
   <!-- END -->
     <!-- Image section -->
     <div class="container">


### PR DESCRIPTION
Fixes #293, 
Info-box Position in results pages for both All and Images now rectified. 
Screenshots:
![image](https://cloud.githubusercontent.com/assets/20185076/26205346/1c4e60b6-3bff-11e7-8214-264de89c8e0c.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26205444/60298ec8-3bff-11e7-9199-e9efde6806c6.png)
P.S Fixing this bug automatically fixed #291
[Demo link ](https://marauderer97.github.io/susper.com/)
