### PR TITLE
Fixes #291, Initial gap between images removed,

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -145,7 +145,8 @@ a {
 }
 
 .grid {
-  padding-left: 80px;
+  padding-left: 30px;
+  padding-right: 30px;
 }
 
 .responsive-image {

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -23,8 +23,8 @@
         </div>
     </div>
     <!-- Basic results 'All' -->
+  <div class="text-result" *ngIf="Display('all')">
     <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
-        <div class="text-result" *ngIf="Display('all')">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
                     <a class="title-pointer" href="{{item.link}}">{{item.title}}</a>
@@ -51,7 +51,6 @@
     </div>
     <!-- END -->
         <div class="video-result" *ngIf="Display('videos')">
-          <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
                     <a class="title-pointer" href="{{item.path}}">{{item.title}}</a>
@@ -60,7 +59,6 @@
                     <p>{{item.link}}</p>
                 </div>
             </div>
-          </div>
 
         </div>
 


### PR DESCRIPTION
Fixes #291, 
Initial gap between images removed, 
image display made similar to market leader.
Screenshot:
![image](https://cloud.githubusercontent.com/assets/20185076/26244925/8113468c-3caf-11e7-91f3-a80bbd4b4d0c.png)
[Demo link](https://marauderer97.github.io/susper.com/)