### PR TITLE
Fixes #298 Design the info box similar to market leader

### DIFF
--- a/src/app/infobox/infobox.component.css
+++ b/src/app/infobox/infobox.component.css
@@ -1,20 +1,39 @@
 .card {
   /* Add shadows to create the "card" effect */
-  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.16),0 0 0 1px rgba(0,0,0,0.08);
   border: 1px solid rgba(150,150,150,0.3);
   border-bottom-color: rgba(125,125,125,0.3);
   margin-bottom: 16px;
   padding: 22px 22px 18px 22px;
-  margin-top: 42px;
   transition: 0.3s;
-}
-
-/* On mouse-over, add a deeper shadow */
-.card:hover {
-  box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
+  width: 100%;
+  margin-left: 20px;
 }
 
 /* Add some padding inside the card container */
 .card-container {
   padding: 2px 16px;
+}
+
+/* Heading */
+h2 {
+  font-size: 2.6em;
+}
+
+/* Description */
+p {
+  line-height: 20px;
+  font-family: Arial, sans-serif;
+  font-size: 13px;
+}
+
+/* Points of interest */
+h3 {
+  font-size: 1.3em;
+  margin-left: -15px;
+}
+
+a {
+  color: #1a0dab;
+  text-decoration: none;
+  margin-left: -11px;
 }

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -15,10 +15,6 @@
   overflow: hidden !important;
   text-overflow: ellipsis;
 }
-.infobox {
-  float:right!important;
-
-}
 
 .link > p {
   color: #006621;


### PR DESCRIPTION
Resolves #298 

Preview link : <a href="https://harshit98.github.io/susper.com/">here</a>

Things I have done in this PR : 
- Worked on the front end part of the info box following the market leader.

Screenshots : 

Before changes :

![screenshot from 2017-05-19 23-31-35](https://cloud.githubusercontent.com/assets/22245418/26261645/a5470ada-3cef-11e7-82ee-05a292429d43.png)

After changes : 

![screenshot from 2017-05-19 23-31-52](https://cloud.githubusercontent.com/assets/22245418/26261649/aac942c0-3cef-11e7-8a5f-ce49974d4b43.png)
 