### PR TITLE
Fixes #279 Searching a keyword will not show loading

### DIFF
--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -141,7 +141,7 @@ export class ResultsComponent implements OnInit {
       this.querylook = Object.assign({}, query);
       this.searchdata.sort = query['sort'];
       this.begin = Number(query['start']) + 1;
-      this.message = 'loading...';
+      this.message = '';
       this.start = (this.presentPage) * this.searchdata.rows;
       this.begin = this.start + 1;
 


### PR DESCRIPTION
Resolves #279 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>

Things I have done in this PR : 
- Removed the `loading...` from the result page following the Google. 

This issue can also be related with #48 

@Marauderer97 @nikhilrayaprolu  Kindly review : )