### PR TITLE
Fixes #114 Video section loading .mp4 files

### DIFF
--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -72,7 +72,7 @@ export class ResultsComponent implements OnInit {
     this.getPresentPage(0);
     this.resultDisplay = 'videos';
     this.searchdata.rows = 10;
-    this.searchdata.fq = 'url_file_ext_s:(avi+OR+mov+OR+flw+OR+gif)';
+    this.searchdata.fq = 'url_file_ext_s:(avi+OR+mov+OR+flw+OR+mp4)';
     this.route.navigate(['/search'], { queryParams: this.searchdata });
   }
 


### PR DESCRIPTION
Resolves #114

Regarding displaying thumbnails, I'll open up a separate issue as it will require some extra work implementing it using an external API.

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>.

Things I have done in this PR : 
- `.gif` files were loading in videos section. In this PR, it has been resolved. Files with format `.avi` and `.mp4` are being loaded.

Screenshots :

![screenshot from 2017-05-20 10-39-40](https://cloud.githubusercontent.com/assets/22245418/26273298/e6319d34-3d4a-11e7-9130-8cd78a989fae.png)

![screenshot from 2017-05-20 10-40-48](https://cloud.githubusercontent.com/assets/22245418/26273299/ea639290-3d4a-11e7-878f-083fd7b2fa91.png)
  