### PR TITLE
Refer #250, Fixed wrong link for codecov in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Susper is a decentralized Search Engine that uses the peer to peer system yacy a
 [![Build Status](https://travis-ci.org/fossasia/susper.com.svg?branch=angular)](https://travis-ci.org/fossasia/susper.com?branch=angular)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2ba119419e7444b3b505bb37b4525deb)](https://www.codacy.com/app/shiven15094/susper-com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fossasia/susper.com&amp;utm_campaign=Badge_Grade)
 [![Code Climate](https://codeclimate.com/github/fossasia/susper.com/badges/gpa.svg?branch=gh-pages)](https://codeclimate.com/github/fossasia/susper.com)
-[![codecov](https://codecov.io/gh/fossasia/susper.com/branch/gh-pages/graph/badge.svg)](https://codecov.io/gh/fossasia/gh-pages)
+[![codecov](https://codecov.io/gh/fossasia/susper.com/branch/gh-pages/graph/badge.svg)](https://codecov.io/gh/fossasia/susper.com)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fossasia/susper.com?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Communication


### PR DESCRIPTION
Refer #250,
he README for the repo shows codecov:unknown and on clicking the link gives 404 error, this is because the link specified was wrong.
![image](https://cloud.githubusercontent.com/assets/20185076/26283385/31722f66-3e45-11e7-935d-d764a98ec72a.png)
Here is the page we will be redirected to with the new link
![image](https://cloud.githubusercontent.com/assets/20185076/26283408/914a06e8-3e45-11e7-8cc4-cced09367218.png)
