### PR TITLE
Fixes #311 contact page contact number country code should be shown rather than country name

### DIFF
--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -54,7 +54,7 @@
     <div class="row">
       <div class="col-lg-12 col-sm-12 contact-sub-details">
         <p>Report a safety or abuse issue affecting our products.<br> If you know of a safety or abuse problem with any of Susper's
-          services, we'd like to hear about it right away. Please use our <a (click)="open()">contact</a> form to report the
+          services, we'd like to hear about it right away. Please use our <a [routerLink]="['/contact']" (click)="open()">contact</a> form to report the
           issue.
         </p>
       </div>
@@ -103,9 +103,9 @@
   <!-- Select Basic -->
   <div class="form-group row">
     <label class="col-md-3 control-label" for="countrycode">Mobile Number<sup>*</sup></label>
-    <div class="col-md-2">
+    <div class="col-md-9">
 
-      <select id="countrycode" name="countrycode" class="form-control">
+    <select id="countrycode" name="countrycode" class="form-control">
               <option data-countryCode="DZ" value="213">Algeria (+213)</option>
               <option data-countryCode="AD" value="376">Andorra (+376)</option>
               <option data-countryCode="AO" value="244">Angola (+244)</option>
@@ -322,9 +322,7 @@
               <option data-countryCode="ZW" value="263">Zimbabwe (+263)</option>
 
       </select>
-    </div>
-    <div class="col-md-7">
-    <input id="telephone" name="telephone" type="text" placeholder="Mobile Number"(ngModelChange)="checkWordCount()" [(ngModel)]=tpnoInput class="form-control input-md" required="">
+    <input id="telephone" name="telephone" type="text" placeholder="Mobile Number"(ngModelChange)="checkWordCount()" [(ngModel)]="tpnoInput" class="form-control input-md" required="">
 
     </div>
   </div>
@@ -333,7 +331,7 @@
   <div class="form-group">
     <label class="col-md-3 control-label" for="message">Message<sup>*</sup></label>
     <div class="col-md-9">
-      <textarea class="form-control" id="message" name="message" placeholder="Minimum 100 words" required=""(ngModelChange)="checkWordCount()" [(ngModel)]=contactMessage></textarea>
+      <textarea class="form-control" id="message" name="message" placeholder="Minimum 100 words" required="" (ngModelChange)="checkWordCount()" [(ngModel)]="contactMessage"></textarea>
     </div>
   </div>
 


### PR DESCRIPTION
in ref #311 
Now the whole country name and codes will be displayed on selecting the country.
![image](https://cloud.githubusercontent.com/assets/15216503/26284548/ab7c9920-3e5b-11e7-85f8-a81979071525.png)

demolink: https://susper-pr-315.herokuapp.com/