### PR TITLE
Fixes #316, Padding for contact form link removed

### DIFF
--- a/src/app/contact/contact.component.css
+++ b/src/app/contact/contact.component.css
@@ -135,7 +135,6 @@
 
 a {
     text-decoration: none;
-    padding-right: 30px;
     color: rgb(119,119,119);
 }
 


### PR DESCRIPTION
Fixes #316, 
Padding for contact form link removed to prevent extra space.
![image](https://cloud.githubusercontent.com/assets/20185076/26284686/e37a65ac-3e5e-11e7-986f-ab5dc396e076.png)
Demo link -[Here](https://marauderer97.github.io/susper.com/)