### PR TITLE
Fixes #320 Search option buttons touches bottom

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -164,7 +164,7 @@ a {
 
 #search-options-field {
   background-color: #f8f8f8;
-  padding-bottom: 6px;
+  padding-bottom: 3px;
 }
 
 #search-options {


### PR DESCRIPTION
Closes #320 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>

Things I have done in this PR : 
- Solved the issue as it has been mentioned. Search option buttons now touches bottom. Earlier there was a gap.