### PR TITLE
Fixes #321, Text now aligned properly for all links in menu

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -24,8 +24,8 @@
 
 .header{
   display: inline-block;
-  width: 70px;
-  padding: 4%;
+  width: 103px;
+  padding: 1%;
   text-align: center;
 }
 
@@ -36,7 +36,7 @@
 }
 
 .dropdown-menu{
-  width: 100px;
+  min-width: 240px;
 }
 
 .dropdown {

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -45,6 +45,8 @@
                                 </a>
                                 <p class="header-text">Bug Reports</p>
                             </div>
+                        </li>
+                      <li>
                           <div class="header" id="header-contact">
                             <a routerLink="/contact" routerLinkActive="active">
                               <i class="fa fa-phone" aria-hidden="true" style="font-size: 2em" id="contact-icon"></i>


### PR DESCRIPTION
Fixes #321, 
As discussed in #321 ,Text now aligned properly for all links in menu by modifying width and padding.
Screenshot:
![image](https://cloud.githubusercontent.com/assets/20185076/26303189/5a0c8d08-3f04-11e7-9eda-49f2fe7c5b1d.png)
Demo link - [Here](https://marauderer97.github.io/susper.com)

