### PR TITLE
Fixes #336, The keyword appears without refresh

### DIFF
--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -24,7 +24,7 @@ export class RelatedSearchComponent implements OnInit {
           if (res.results) {
             res.results.splice(0, 1);
             this.results = res.results;
-            this.keyword = this.query$._dispatcher._value.payload.query;
+            this.keyword = query;
           }
 
         });


### PR DESCRIPTION
Fixes #336, 
The keyword appears without refresh, Searches related to doesn't cause problems now.
![image](https://cloud.githubusercontent.com/assets/20185076/26418421/c9024b22-40d9-11e7-9132-f32b9933f5d1.png)
Test link :[ Here](https://marauderer97.github.io/susper.com/)