### PR TITLE
Fixes #338 related searches being displayed before the actual search

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -36,7 +36,7 @@
                     <p>{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
                 </div>
             </div>
-      <app-related-search></app-related-search>
+      <app-related-search [hidden]="hidefooter"></app-related-search>
         </div>
     </div>
 


### PR DESCRIPTION
Now the related searches will be diplayed only after the search is completed.
in reference to issue #338 

deployment demo link:- https://susper-pr-339.herokuapp.com/