### PR TITLE
Fixes #335 infobox gives irrelevant information at times

### DIFF
--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -21,7 +21,12 @@ export class InfoboxComponent implements OnInit {
       if (query) {
         this.knowledgeservice.getsearchresults(query).subscribe(res => {
           if (res.results) {
-            this.results = res.results;
+            if (res.results[0].label.toLowerCase().includes(query.toLowerCase())) {
+              this.results = res.results;
+            } else {
+              this.results = [];
+            }
+
           }
         });
       }


### PR DESCRIPTION
Now infobox shows empty when there is irrelevant information.
in reference to issue #335 ,  now similar to google 

![image](https://cloud.githubusercontent.com/assets/15216503/26439622/9924405a-4146-11e7-9aa6-30ff7f00a595.png)

before:-

![image](https://cloud.githubusercontent.com/assets/15216503/26439694/ce28f6c4-4146-11e7-868e-8b8f33eb9cda.png)

demo link:-https://susper-pr-340.herokuapp.com/