### PR TITLE
Fixes #334 removes previous and next button on single page

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -65,7 +65,7 @@
 
         <br>
         <div class="clean"></div>
-        <div class="pagination-property">
+        <div class="pagination-property" *ngIf="noOfPages>1">
             <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
                 <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
                 <ul class="pagination" id="pag-bar">

--- a/src/app/results/results.component.spec.ts
+++ b/src/app/results/results.component.spec.ts
@@ -91,11 +91,4 @@ describe('ResultsComponent', () => {
     expect(textResult).toBeTruthy();
   });
 
-
-  it('should have pagination property', () => {
-    let compiled = fixture.debugElement.nativeElement;
-    let pagination = compiled.querySelector('div.pagination-property');
-
-    expect(pagination).toBeTruthy();
-  });
 });


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/15216503/26440132/85ce1d80-4148-11e7-969c-a339242c0c95.png)

in reference to issue #334 removed the whole pagination bar on single page.
demo link:- https://susper-pr-341.herokuapp.com/