### PR TITLE
Fixes #343 removing the related search results when there is no query

### DIFF
--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -25,9 +25,14 @@ export class RelatedSearchComponent implements OnInit {
             res.results.splice(0, 1);
             this.results = res.results;
             this.keyword = query;
-          }
+
+        } else {
+          this.results = [];
+        }
 
         });
+      } else {
+        this.results = [];
       }
     });
   }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/15216503/26441172/14bf67e8-414d-11e7-8c3d-8e852f96d9b8.png)

in reference to issue #343 now the related searches are removed on no query.
demo link:- https://susper-pr-345.herokuapp.com/