### PR TITLE
Addresses #269 Theme feature for Susper

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -22,6 +22,7 @@ import { ContactComponent } from '../contact/contact.component';
 import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -53,6 +54,7 @@ describe('AboutComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/advancedsearch/advancedsearch.component.spec.ts
+++ b/src/app/advancedsearch/advancedsearch.component.spec.ts
@@ -23,6 +23,7 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('AdvancedsearchComponent', () => {
   let component: AdvancedsearchComponent;
@@ -54,7 +55,8 @@ describe('AdvancedsearchComponent', () => {
         ContactComponent,
         ModalComponent,
         InfoboxComponent,
-        RelatedSearchComponent
+        RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -23,6 +23,7 @@ import { ContactComponent } from './contact/contact.component';
 import { ModalComponent, Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "./infobox/infobox.component";
 import {RelatedSearchComponent} from "./related-search/related-search.component";
+import { CustomizeComponent } from './customize/customize.component';
 
 describe('AppComponent', () => {
   beforeEach(() => {
@@ -50,7 +51,8 @@ describe('AppComponent', () => {
         ContactComponent,
         ModalComponent,
         InfoboxComponent,
-        RelatedSearchComponent
+        RelatedSearchComponent,
+        CustomizeComponent
       ]
     });
     TestBed.compileComponents();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,8 @@ import { NewadvancedsearchComponent } from './newadvancedsearch/newadvancedsearc
 import { InfoboxComponent } from './infobox/infobox.component';
 import {KnowledgeapiService} from './knowledgeapi.service';
 import { RelatedSearchComponent } from './related-search/related-search.component';
+import { CustomizeComponent } from './customize/customize.component';
+import { ThemeService } from './theme.service';
 
 
 const appRoutes: Routes = [
@@ -54,6 +56,7 @@ const appRoutes: Routes = [
     NewadvancedsearchComponent,
     InfoboxComponent,
     RelatedSearchComponent,
+    CustomizeComponent,
   ],
   imports: [
     BrowserModule,
@@ -68,7 +71,7 @@ const appRoutes: Routes = [
     Ng2Bs3ModalModule
 
   ],
-  providers: [SearchService, KnowledgeapiService],
+  providers: [SearchService, KnowledgeapiService, ThemeService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/contact/contact.component.spec.ts
+++ b/src/app/contact/contact.component.spec.ts
@@ -21,6 +21,7 @@ import { AboutComponent } from '../about/about.component';
 import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('ContactComponent', () => {
   let component: ContactComponent;
@@ -52,7 +53,7 @@ describe('ContactComponent', () => {
         ContactComponent,
         InfoboxComponent,
         RelatedSearchComponent,
-
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/customize/customize.component.html
+++ b/src/app/customize/customize.component.html
@@ -1,0 +1,14 @@
+<div class="modal-dialog" role="document">
+  <div class="modal-content">
+    <div class="modal-header">
+      <!-- Start ignoring HTMLLintBear -->
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <!-- Stop ignoring HTMLLintBear -->
+      <h3 class="modal-title" id="my-modal-label">Customization</h3>
+    </div>
+    <div class="modal-body">
+      <button type="button" (click)="darkTheme()" data-theme="dark" class="theme-link">Dark Theme</button>
+      <button type="button" (click)="defaultTheme()" data-theme="default" class="theme-link">Default Theme</button>
+    </div>
+  </div>
+</div>

--- a/src/app/customize/customize.component.spec.ts
+++ b/src/app/customize/customize.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CustomizeComponent } from './customize.component';
+import { ThemeService } from '../theme.service';
+
+describe('CustomizeComponent', () => {
+  let component: CustomizeComponent;
+  let fixture: ComponentFixture<CustomizeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CustomizeComponent
+      ],
+      providers: [
+        ThemeService
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CustomizeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/customize/customize.component.ts
+++ b/src/app/customize/customize.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { ThemeService } from '../theme.service';
+
+@Component({
+  selector: 'app-customize',
+  templateUrl: './customize.component.html',
+  styleUrls: ['./customize.component.css']
+})
+export class CustomizeComponent implements OnInit {
+
+  constructor(
+    private themeService: ThemeService
+  ) { }
+
+  ngOnInit() {
+  }
+
+  darkTheme() {
+    this.themeService.titleColor = '#050404';
+    this.themeService.linkColor = '#7E716E';
+    this.themeService.descriptionColor = '#494443';
+  }
+
+  defaultTheme() {
+    this.themeService.titleColor = '#1a0dab';
+    this.themeService.linkColor = '#006621';
+    this.themeService.descriptionColor = '#545454';
+  }
+
+}

--- a/src/app/footer-navbar/footer-navbar.component.spec.ts
+++ b/src/app/footer-navbar/footer-navbar.component.spec.ts
@@ -22,6 +22,7 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('FooterNavbarComponent', () => {
   let component: FooterNavbarComponent;
@@ -53,6 +54,7 @@ describe('FooterNavbarComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/index/index.component.spec.ts
+++ b/src/app/index/index.component.spec.ts
@@ -23,6 +23,7 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('IndexComponent', () => {
   let component: IndexComponent;
@@ -54,6 +55,7 @@ describe('IndexComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/infobox/infobox.component.spec.ts
+++ b/src/app/infobox/infobox.component.spec.ts
@@ -22,6 +22,7 @@ import {reducer} from "../reducers/index";
 import {StoreModule} from "@ngrx/store";
 import {StoreDevtoolsModule} from "@ngrx/store-devtools";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('InfoboxComponent', () => {
   let component: InfoboxComponent;
@@ -53,6 +54,7 @@ describe('InfoboxComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ],
       providers: [
         KnowledgeapiService

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -23,6 +23,7 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
@@ -54,6 +55,7 @@ describe('NavbarComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/not-found/not-found.component.spec.ts
+++ b/src/app/not-found/not-found.component.spec.ts
@@ -23,6 +23,7 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('NotFoundComponent', () => {
   let component: NotFoundComponent;
@@ -54,6 +55,7 @@ describe('NotFoundComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/related-search/related-search.component.spec.ts
+++ b/src/app/related-search/related-search.component.spec.ts
@@ -23,6 +23,7 @@ import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import { RelatedSearchComponent } from './related-search.component';
 import {KnowledgeapiService} from "../knowledgeapi.service";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('RelatedSearchComponent', () => {
   let component: RelatedSearchComponent;
@@ -54,6 +55,7 @@ describe('RelatedSearchComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ],
       providers: [
         KnowledgeapiService

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -12,7 +12,8 @@
                 <ul class="dropdown-menu" aria-labelledby="tools" id="tool-dropdown">
                     <li (click)="filterByContext()">Context Ranking</li>
                     <li (click)="filterByDate()">Sort by Date</li>
-                    <li data-toggle="modal" data-target="#myModal" (click)="advancedsearch()">Advanced Search</li>
+                    <li data-toggle="modal" data-target="#myModal">Advanced Search</li>
+                    <li data-toggle="modal" data-target="#customization">Customization</li>
                 </ul>
             </li>
         </ul>
@@ -27,13 +28,13 @@
     <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
-                    <a class="title-pointer" href="{{item.link}}">{{item.title}}</a>
+                    <a class="title-pointer" href="{{item.link}}" [style.color]="themeService.titleColor">{{item.title}}</a>
                 </div>
                 <div class="link">
-                    <p>{{item.link}}</p>
+                    <p [style.color]="themeService.linkColor">{{item.link}}</p>
                 </div>
                 <div class="description">
-                    <p>{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
+                    <p [style.color]="themeService.descriptionColor">{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
                 </div>
             </div>
       <app-related-search [hidden]="hidefooter"></app-related-search>
@@ -81,6 +82,9 @@
         </div>
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <app-advancedsearch></app-advancedsearch>
+</div>
+<div class="modal fade" id="customization" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <app-customize></app-customize>
 </div>
 
 <!--footer navigation bar goes here-->

--- a/src/app/results/results.component.spec.ts
+++ b/src/app/results/results.component.spec.ts
@@ -25,6 +25,8 @@ import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {KnowledgeapiService} from "../knowledgeapi.service";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
+import { ThemeService } from '../theme.service';
 
 describe('ResultsComponent', () => {
   let component: ResultsComponent;
@@ -56,8 +58,9 @@ describe('ResultsComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ],
-      providers: [SearchService, KnowledgeapiService]
+      providers: [SearchService, KnowledgeapiService, ThemeService]
     })
       .compileComponents();
   }));

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { SearchService } from '../search.service';
+import { ThemeService } from '../theme.service';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import * as fromRoot from '../reducers';
@@ -109,7 +110,7 @@ export class ResultsComponent implements OnInit {
   }
 
   constructor(private searchservice: SearchService, private route: Router, private activatedroute: ActivatedRoute,
-              private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
+              private store: Store<fromRoot.State>, private ref: ChangeDetectorRef, public themeService: ThemeService) {
 
     this.activatedroute.queryParams.subscribe(query => {
       this.hidefooter = 1;

--- a/src/app/search-bar/search-bar.component.spec.ts
+++ b/src/app/search-bar/search-bar.component.spec.ts
@@ -23,6 +23,7 @@ import { ContactComponent } from '../contact/contact.component';
 import { ModalComponent, Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('SearchBarComponent', () => {
   let component: SearchBarComponent;
@@ -55,6 +56,7 @@ describe('SearchBarComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
       .compileComponents();

--- a/src/app/terms/terms.component.spec.ts
+++ b/src/app/terms/terms.component.spec.ts
@@ -21,6 +21,7 @@ import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { TermsComponent } from './terms.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import { CustomizeComponent } from '../customize/customize.component';
 
 describe('TermsComponent', () => {
   let component: TermsComponent;
@@ -51,6 +52,7 @@ describe('TermsComponent', () => {
         TermsComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        CustomizeComponent
       ]
     })
     .compileComponents();

--- a/src/app/theme.service.spec.ts
+++ b/src/app/theme.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ThemeService]
+    });
+  });
+
+  it('should be created', inject([ThemeService], (service: ThemeService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/theme.service.ts
+++ b/src/app/theme.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ThemeService {
+
+  public titleColor: string;
+  public linkColor: string;
+  public descriptionColor: string;
+
+  constructor() { }
+
+}


### PR DESCRIPTION
Addresses #269 

Preview link - <a href="https://harshit98.github.io/susper.com/">here</a>.

Previously, I was having a lot of conflicts which were not solved due to some recent merges of PRs. (See #333 )

Things I have done in this PR -
-  Provided the theme for Susper. We can start adding up themes for susper from this step.

Go `Tools` -> `Customization`. It will open up a modal and user can choose a desired theme. I have not much worked on theme. It will just change colour of title and description in the results section.