### PR TITLE
Addresses #121, uses dbpedia prefix searching to implement autocomplete

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -22,6 +22,7 @@ import { ContactComponent } from '../contact/contact.component';
 import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -53,6 +54,7 @@ describe('AboutComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
       ]
     })
       .compileComponents();

--- a/src/app/advancedsearch/advancedsearch.component.spec.ts
+++ b/src/app/advancedsearch/advancedsearch.component.spec.ts
@@ -23,6 +23,7 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('AdvancedsearchComponent', () => {
   let component: AdvancedsearchComponent;
@@ -54,7 +55,8 @@ describe('AdvancedsearchComponent', () => {
         ContactComponent,
         ModalComponent,
         InfoboxComponent,
-        RelatedSearchComponent
+        RelatedSearchComponent,
+        AutoCompleteComponent,
       ]
     })
       .compileComponents();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -23,6 +23,7 @@ import { ContactComponent } from './contact/contact.component';
 import { ModalComponent, Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "./infobox/infobox.component";
 import {RelatedSearchComponent} from "./related-search/related-search.component";
+import {AutoCompleteComponent} from "./auto-complete/auto-complete.component";
 
 describe('AppComponent', () => {
   beforeEach(() => {
@@ -50,7 +51,8 @@ describe('AppComponent', () => {
         ContactComponent,
         ModalComponent,
         InfoboxComponent,
-        RelatedSearchComponent
+        RelatedSearchComponent,
+        AutoCompleteComponent,
       ]
     });
     TestBed.compileComponents();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,8 @@ import { NewadvancedsearchComponent } from './newadvancedsearch/newadvancedsearc
 import { InfoboxComponent } from './infobox/infobox.component';
 import {KnowledgeapiService} from './knowledgeapi.service';
 import { RelatedSearchComponent } from './related-search/related-search.component';
+import {AutocompleteService} from "./autocomplete.service";
+import { AutoCompleteComponent } from './auto-complete/auto-complete.component';
 
 
 const appRoutes: Routes = [
@@ -54,6 +56,7 @@ const appRoutes: Routes = [
     NewadvancedsearchComponent,
     InfoboxComponent,
     RelatedSearchComponent,
+    AutoCompleteComponent,
   ],
   imports: [
     BrowserModule,
@@ -68,7 +71,7 @@ const appRoutes: Routes = [
     Ng2Bs3ModalModule
 
   ],
-  providers: [SearchService, KnowledgeapiService],
+  providers: [SearchService, KnowledgeapiService, AutocompleteService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/auto-complete/auto-complete.component.css
+++ b/src/app/auto-complete/auto-complete.component.css
@@ -1,0 +1,12 @@
+a{
+  text-decoration: none;
+  font-family: Arial, sans-serif;
+  padding-bottom: 1%;
+}
+
+.suggestion-box{
+  width: 100%;
+  border: solid;
+  background-color: white;
+  padding: 1%;
+}

--- a/src/app/auto-complete/auto-complete.component.html
+++ b/src/app/auto-complete/auto-complete.component.html
@@ -1,0 +1,5 @@
+<div class="suggestion-box">
+<div *ngFor="let result of results">
+  <a [routerLink]="resultsearch" [queryParams]="{query: result.label}">{{result.label}}</a>
+</div>
+</div>

--- a/src/app/auto-complete/auto-complete.component.spec.ts
+++ b/src/app/auto-complete/auto-complete.component.spec.ts
@@ -1,0 +1,74 @@
+  import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AutoCompleteComponent } from './auto-complete.component';
+  import {AutocompleteService} from "../autocomplete.service";
+  import {RelatedSearchComponent} from "../related-search/related-search.component";
+  import {InfoboxComponent} from "../infobox/infobox.component";
+  import {ModalComponent} from "ng2-bs3-modal/components/modal";
+  import {ContactComponent} from "../contact/contact.component";
+  import {AboutComponent} from "../about/about.component";
+  import {FooterNavbarComponent} from "../footer-navbar/footer-navbar.component";
+  import {AppComponent} from "../app.component";
+  import {NavbarComponent} from "../navbar/navbar.component";
+  import {IndexComponent} from "../index/index.component";
+  import {ResultsComponent} from "../results/results.component";
+  import {NotFoundComponent} from "../not-found/not-found.component";
+  import {AdvancedsearchComponent} from "../advancedsearch/advancedsearch.component";
+  import {SearchBarComponent} from "../search-bar/search-bar.component";
+  import {StoreDevtoolsModule} from "@ngrx/store-devtools";
+  import {reducer} from "../reducers/index";
+  import {StoreModule} from "@ngrx/store";
+  import {JsonpModule, HttpModule} from "@angular/http";
+  import {FormsModule} from "@angular/forms";
+  import {CommonModule} from "@angular/common";
+  import {BrowserModule} from "@angular/platform-browser";
+  import {RouterTestingModule} from "@angular/router/testing";
+
+describe('AutoCompleteComponent', () => {
+  let component: AutoCompleteComponent;
+  let fixture: ComponentFixture<AutoCompleteComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        BrowserModule,
+        CommonModule,
+        FormsModule,
+        HttpModule,
+        JsonpModule,
+        StoreModule.provideStore(reducer),
+        StoreDevtoolsModule.instrumentOnlyWithExtension(),
+      ],
+      declarations: [
+        AppComponent,
+        NavbarComponent,
+        IndexComponent,
+        ResultsComponent,
+        NotFoundComponent,
+        AdvancedsearchComponent,
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent,
+        ContactComponent,
+        ModalComponent,
+        InfoboxComponent,
+        RelatedSearchComponent,
+        AutoCompleteComponent,
+      ],
+      providers: [
+       AutocompleteService ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AutoCompleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/auto-complete/auto-complete.component.ts
+++ b/src/app/auto-complete/auto-complete.component.ts
@@ -1,0 +1,37 @@
+import {Component, OnInit, ChangeDetectorRef} from '@angular/core';
+import {AutocompleteService} from "../autocomplete.service";
+import {Router, ActivatedRoute} from "@angular/router";
+import {Store} from "@ngrx/store";
+import * as fromRoot from '../reducers';
+import {KnowledgeapiService} from "../knowledgeapi.service";
+
+@Component({
+  selector: 'app-auto-complete',
+  templateUrl: './auto-complete.component.html',
+  styleUrls: ['./auto-complete.component.css']
+})
+export class AutoCompleteComponent implements OnInit {
+
+  results: Array<any>;
+  query$: any;
+  resultsearch = '/search';
+  constructor(private autocompleteservice: AutocompleteService, private route: Router, private activatedroute: ActivatedRoute,
+              private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
+    this.query$ = store.select(fromRoot.getquery);
+    this.query$.subscribe( query => {
+      if (query) {
+        this.autocompleteservice.getsearchresults(query).subscribe(res => {
+          if (res.results) {
+            this.results = res.results;
+          } else {
+            this.results = [];
+          }
+        });
+      }
+    });
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/autocomplete.service.spec.ts
+++ b/src/app/autocomplete.service.spec.ts
@@ -3,12 +3,25 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { AutocompleteService } from './autocomplete.service';
 import { RouterTestingModule } from '@angular/router/testing';
+import {HttpModule, JsonpModule} from "@angular/http";
+import {StoreModule} from "@ngrx/store";
+import {StoreDevtoolsModule} from "@ngrx/store-devtools";
+import {reducer} from "./reducers/index";
 
 describe('AutocompleteService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [
+        HttpModule,
+        JsonpModule,
+        StoreModule.provideStore(reducer),
+        StoreDevtoolsModule.instrumentOnlyWithExtension(),
+      ],
       providers: [AutocompleteService]
     });
   });
+
+  it('should ...', inject([AutocompleteService], (service: AutocompleteService) => {
+    expect(service).toBeTruthy();
+  }));
 });

--- a/src/app/autocomplete.service.ts
+++ b/src/app/autocomplete.service.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { Injectable } from '@angular/core';
-import {Http, URLSearchParams, Jsonp, Response} from '@angular/http';
+import {Http, URLSearchParams, Jsonp, Response, Headers, RequestOptions} from '@angular/http';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/toPromise';
 import {Store} from '@ngrx/store';
@@ -10,38 +10,36 @@ import * as search from './actions/search';
 import * as fromRoot from './reducers';
 
 @Injectable()
-export class AutocompleteService implements OnInit {
-  server = 'yacy.searchlab.eu';
-  suggestUrl = 'http://' + this.server + '/suggest.json?callback=?';
-  data: Observable<any>;
-  search: any = {
-    query: '',
-    verify: false,
-    nav: 'filetype,protocol,hosts,authors,collections,namespace,topics,date',
-    start: 0,
-    indexof: 'off',
-    meanCount: '5',
-    resource: 'global',
-    prefermaskfilter: '',
-    timezoneOffset: 0,
-  };
+export class AutocompleteService {
+  server = 'http://lookup.dbpedia.org';
+  searchURL = this.server + '/api/search/PrefixSearch?';
+  homepage = 'http://susper.com';
+  logo = '../images/susper.svg';
+  constructor(private http: Http, private jsonp: Jsonp, private store: Store<fromRoot.State>) {
+  }
+  getsearchresults(searchquery) {
 
-  private searchTerms = new Subject<string>();
+    let params = new URLSearchParams();
+    params.set('QueryString', searchquery);
+   // params.set('QueryClass', 'MaxHits=5');
 
-  onquery(term: string): void {
-    this.searchTerms.next(term);
+    let headers = new Headers({ 'Accept': 'application/json' });
+    let options = new RequestOptions({ headers: headers, search: params });
+    return this.http
+      .get(this.searchURL, options).map(res =>
+
+        res.json()
+
+      ).catch(this.handleError);
+
+  }
+  private handleError (error: any) {
+    // In some advance version we can include a remote logging of errors
+    let errMsg = (error.message) ? error.message :
+      error.status ? `${error.status} - ${error.statusText}` : 'Server error';
+    console.error(errMsg); // Right now we are logging to console itself
+    return Observable.throw(errMsg);
   }
 
-  constructor(private searchService: AutocompleteService) { }
 
-  ngOnInit(): void {
-    this.data = this.searchTerms
-      .debounceTime(300) // pause in events
-      .distinctUntilChanged() // ignore if search term not changed
-      .switchMap(term => term // switch to new observable each time
-        // http service to retrieve data
-        ? this.searchService.search(term)
-        : Observable.of<any>([])
-      );
-  }
 }

--- a/src/app/contact/contact.component.spec.ts
+++ b/src/app/contact/contact.component.spec.ts
@@ -21,6 +21,7 @@ import { AboutComponent } from '../about/about.component';
 import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('ContactComponent', () => {
   let component: ContactComponent;
@@ -52,6 +53,7 @@ describe('ContactComponent', () => {
         ContactComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
 
       ]
     })

--- a/src/app/footer-navbar/footer-navbar.component.spec.ts
+++ b/src/app/footer-navbar/footer-navbar.component.spec.ts
@@ -22,6 +22,7 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('FooterNavbarComponent', () => {
   let component: FooterNavbarComponent;
@@ -53,6 +54,7 @@ describe('FooterNavbarComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
       ]
     })
       .compileComponents();

--- a/src/app/index/index.component.spec.ts
+++ b/src/app/index/index.component.spec.ts
@@ -23,6 +23,8 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutocompleteService} from "../autocomplete.service";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('IndexComponent', () => {
   let component: IndexComponent;
@@ -54,7 +56,11 @@ describe('IndexComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
-      ]
+        AutoCompleteComponent,
+      ],
+      providers: [
+        AutocompleteService
+      ],
     })
       .compileComponents();
   }));

--- a/src/app/infobox/infobox.component.spec.ts
+++ b/src/app/infobox/infobox.component.spec.ts
@@ -22,6 +22,7 @@ import {reducer} from "../reducers/index";
 import {StoreModule} from "@ngrx/store";
 import {StoreDevtoolsModule} from "@ngrx/store-devtools";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('InfoboxComponent', () => {
   let component: InfoboxComponent;
@@ -53,6 +54,7 @@ describe('InfoboxComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
       ],
       providers: [
         KnowledgeapiService

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -23,6 +23,8 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import {AutocompleteService} from "../autocomplete.service";
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
@@ -54,7 +56,11 @@ describe('NavbarComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
-      ]
+        AutoCompleteComponent,
+      ],
+      providers: [
+        AutocompleteService,
+      ],
     })
       .compileComponents();
   }));

--- a/src/app/not-found/not-found.component.spec.ts
+++ b/src/app/not-found/not-found.component.spec.ts
@@ -23,6 +23,8 @@ import { Ng2Bs3ModalModule, ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import {AutocompleteService} from "../autocomplete.service";
 
 describe('NotFoundComponent', () => {
   let component: NotFoundComponent;
@@ -54,6 +56,10 @@ describe('NotFoundComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
+      ],
+      providers: [
+        AutocompleteService
       ]
     })
       .compileComponents();

--- a/src/app/related-search/related-search.component.spec.ts
+++ b/src/app/related-search/related-search.component.spec.ts
@@ -23,6 +23,8 @@ import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import { RelatedSearchComponent } from './related-search.component';
 import {KnowledgeapiService} from "../knowledgeapi.service";
+import {AutocompleteService} from "../autocomplete.service";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('RelatedSearchComponent', () => {
   let component: RelatedSearchComponent;
@@ -54,6 +56,7 @@ describe('RelatedSearchComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
       ],
       providers: [
         KnowledgeapiService

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -5,7 +5,7 @@
             <li [class.active_view]="Display('all')" (click)="docClick()">All</li>
             <li [class.active_view]="Display('images')" (click)="imageClick()">Images</li>
             <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
-            <li class="dropdown">
+          <li class="dropdown">
                 <a href="#" id="tools" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     Tools
                 </a>

--- a/src/app/results/results.component.spec.ts
+++ b/src/app/results/results.component.spec.ts
@@ -25,6 +25,8 @@ import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {KnowledgeapiService} from "../knowledgeapi.service";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import {AutocompleteService} from "../autocomplete.service";
 
 describe('ResultsComponent', () => {
   let component: ResultsComponent;
@@ -56,8 +58,9 @@ describe('ResultsComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
       ],
-      providers: [SearchService, KnowledgeapiService]
+      providers: [SearchService, KnowledgeapiService, AutocompleteService]
     })
       .compileComponents();
   }));

--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -12,6 +12,7 @@
       </button>
     </div>
   </div>
+  <app-auto-complete></app-auto-complete>
 </form>
 <script>
   $(document).ready(function(){

--- a/src/app/search-bar/search-bar.component.spec.ts
+++ b/src/app/search-bar/search-bar.component.spec.ts
@@ -23,6 +23,8 @@ import { ContactComponent } from '../contact/contact.component';
 import { ModalComponent, Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutocompleteService} from "../autocomplete.service";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('SearchBarComponent', () => {
   let component: SearchBarComponent;
@@ -55,7 +57,11 @@ describe('SearchBarComponent', () => {
         ModalComponent,
         InfoboxComponent,
         RelatedSearchComponent,
-      ]
+        AutoCompleteComponent,
+      ],
+      providers: [
+        AutocompleteService
+      ],
     })
       .compileComponents();
   }));

--- a/src/app/terms/terms.component.spec.ts
+++ b/src/app/terms/terms.component.spec.ts
@@ -21,6 +21,7 @@ import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import { TermsComponent } from './terms.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 
 describe('TermsComponent', () => {
   let component: TermsComponent;
@@ -51,6 +52,7 @@ describe('TermsComponent', () => {
         TermsComponent,
         InfoboxComponent,
         RelatedSearchComponent,
+        AutoCompleteComponent,
       ]
     })
     .compileComponents();


### PR DESCRIPTION
Addresses #121, 
uses dbpedia prefix searching to implement autocomplete.
In this pr dbpedia's api is used to implement auto complete
Screenshot:
![image](https://cloud.githubusercontent.com/assets/20185076/26452026/09372292-417c-11e7-9d2b-aab02b372b47.png)

I have not been able to render the auto complete box entirely, please consider this a first iteration, we can then work on how to integrate it properly.
Demo link - [Here](https://marauderer97.github.io/susper.com/)