### PR TITLE
Fixes #354 now all three related searches, infobox and the results change at the same time

### DIFF
--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -38,12 +38,12 @@ export class InfoboxComponent implements OnInit {
             }
 
           } else {
-            this.results = [];
+            this.initialresults = [];
           }
 
         });
       }else {
-        this.results = [];
+        this.initialresults = [];
       }
     });
   }

--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -3,6 +3,7 @@ import {Router, ActivatedRoute} from '@angular/router';
 import {Store} from '@ngrx/store';
 import * as fromRoot from '../reducers';
 import {KnowledgeapiService} from '../knowledgeapi.service';
+import {Observable} from "rxjs";
 
 @Component({
   selector: 'app-infobox',
@@ -13,18 +14,27 @@ export class InfoboxComponent implements OnInit {
   results: Array<any>;
   query$: any;
   resultsearch = '/search';
+  initialresults: Array<any>;
+  resultscomponentchange$: Observable<any>;
+
   constructor(private knowledgeservice: KnowledgeapiService, private route: Router, private activatedroute: ActivatedRoute,
               private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
     this.query$ = store.select(fromRoot.getquery);
-    console.log(this.query$);
+    this.resultscomponentchange$ = store.select(fromRoot.getItems);
+    this.resultscomponentchange$.subscribe(res => {
+      this.results = this.initialresults;
+    });
+
+
+
     this.query$.subscribe( query => {
       if (query) {
         this.knowledgeservice.getsearchresults(query).subscribe(res => {
           if (res.results) {
             if (res.results[0].label.toLowerCase().includes(query.toLowerCase())) {
-              this.results = res.results;
+              this.initialresults = res.results;
             } else {
-              this.results = [];
+              this.initialresults = [];
             }
 
           } else {

--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -42,13 +42,13 @@ export class RelatedSearchComponent implements OnInit {
             this.keyword = query;
 
           } else {
-            this.results = [];
+            this.initialresults = [];
             this.keyword = query;
           }
 
         });
       } else {
-        this.results = [];
+        this.initialresults = [];
       }
     });
   }

--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -3,6 +3,7 @@ import {Router, ActivatedRoute} from '@angular/router';
 import {Store} from '@ngrx/store';
 import * as fromRoot from '../reducers';
 import {KnowledgeapiService} from '../knowledgeapi.service';
+import {Observable} from "rxjs";
 
 @Component({
   selector: 'app-related-search',
@@ -15,18 +16,28 @@ export class RelatedSearchComponent implements OnInit {
   query$: any;
   keyword: any;
   resultsearch = '/search';
+  initialresults: Array<any>;
+  resultscomponentchange$: Observable<any>;
+
   constructor(private knowledgeservice: KnowledgeapiService, private route: Router, private activatedroute: ActivatedRoute,
               private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
     this.query$ = store.select(fromRoot.getquery);
+
+    this.resultscomponentchange$ = store.select(fromRoot.getItems);
+    this.resultscomponentchange$.subscribe(res => {
+      this.results = this.initialresults;
+    });
+
+
     this.query$.subscribe( query => {
       if (query) {
         this.knowledgeservice.getsearchresults(query).subscribe(res => {
           if (res.results) {
             if (!res.results[0].label.toLowerCase().localeCompare(query.toLowerCase())) {
               res.results.splice(0, 1);
-              this.results = res.results;
+              this.initialresults = res.results;
             } else {
-              this.results = res.results;
+              this.initialresults = res.results;
             }
             this.keyword = query;
           } else {

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -151,7 +151,6 @@ export class ResultsComponent implements OnInit {
       this.totalResults$.subscribe(totalResults => {
         if (totalResults) {
           this.hidefooter = 0;
-
         }
         this.end = Math.min(totalResults, this.begin + this.searchdata.rows - 1);
         this.message = 'showing results ' + this.begin + ' to ' + this.end + ' of ' + totalResults;


### PR DESCRIPTION
in reference to issue #354 now all three render at the same time on query change in the search bar.
demolink:- https://susper-pr-355.herokuapp.com/