### PR TITLE
Fixes #356 now no results are shown when there is no response from dbpedia

### DIFF
--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -27,6 +27,8 @@ export class InfoboxComponent implements OnInit {
               this.results = [];
             }
 
+          } else {
+            this.results = [];
           }
         });
       }

--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -29,6 +29,9 @@ export class RelatedSearchComponent implements OnInit {
               this.results = res.results;
             }
             this.keyword = query;
+          } else {
+            this.results = [];
+            this.keyword = query;
           }
 
         });


### PR DESCRIPTION
Inreference to issue #356 
Now no results are displayed when there is no response from dbpedia.
![image](https://cloud.githubusercontent.com/assets/15216503/26500484/b917ed86-4253-11e7-8bed-e2983730abdc.png)

demo link:https://nikhilrayaprolu.github.io/susper.com-1/