### PR TITLE
Addresses #269 Theme feature for Susper

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -23,6 +23,7 @@ import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -55,6 +56,7 @@ describe('AboutComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ]
     })
       .compileComponents();

--- a/src/app/advancedsearch/advancedsearch.component.spec.ts
+++ b/src/app/advancedsearch/advancedsearch.component.spec.ts
@@ -24,6 +24,7 @@ import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('AdvancedsearchComponent', () => {
   let component: AdvancedsearchComponent;
@@ -57,6 +58,7 @@ describe('AdvancedsearchComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ]
     })
       .compileComponents();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -24,6 +24,7 @@ import { ModalComponent, Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "./infobox/infobox.component";
 import {RelatedSearchComponent} from "./related-search/related-search.component";
 import {AutoCompleteComponent} from "./auto-complete/auto-complete.component";
+import { ThemeComponent } from './theme/theme.component';
 
 describe('AppComponent', () => {
   beforeEach(() => {
@@ -53,6 +54,7 @@ describe('AppComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ]
     });
     TestBed.compileComponents();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,8 @@ import {KnowledgeapiService} from './knowledgeapi.service';
 import { RelatedSearchComponent } from './related-search/related-search.component';
 import {AutocompleteService} from "./autocomplete.service";
 import { AutoCompleteComponent } from './auto-complete/auto-complete.component';
+import { ThemeComponent } from './theme/theme.component';
+import { ThemeService } from './theme.service';
 
 
 const appRoutes: Routes = [
@@ -57,6 +59,7 @@ const appRoutes: Routes = [
     InfoboxComponent,
     RelatedSearchComponent,
     AutoCompleteComponent,
+    ThemeComponent,
   ],
   imports: [
     BrowserModule,
@@ -71,7 +74,7 @@ const appRoutes: Routes = [
     Ng2Bs3ModalModule
 
   ],
-  providers: [SearchService, KnowledgeapiService, AutocompleteService],
+  providers: [SearchService, KnowledgeapiService, AutocompleteService, ThemeService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/auto-complete/auto-complete.component.spec.ts
+++ b/src/app/auto-complete/auto-complete.component.spec.ts
@@ -1,28 +1,29 @@
-  import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AutoCompleteComponent } from './auto-complete.component';
-  import {AutocompleteService} from "../autocomplete.service";
-  import {RelatedSearchComponent} from "../related-search/related-search.component";
-  import {InfoboxComponent} from "../infobox/infobox.component";
-  import {ModalComponent} from "ng2-bs3-modal/components/modal";
-  import {ContactComponent} from "../contact/contact.component";
-  import {AboutComponent} from "../about/about.component";
-  import {FooterNavbarComponent} from "../footer-navbar/footer-navbar.component";
-  import {AppComponent} from "../app.component";
-  import {NavbarComponent} from "../navbar/navbar.component";
-  import {IndexComponent} from "../index/index.component";
-  import {ResultsComponent} from "../results/results.component";
-  import {NotFoundComponent} from "../not-found/not-found.component";
-  import {AdvancedsearchComponent} from "../advancedsearch/advancedsearch.component";
-  import {SearchBarComponent} from "../search-bar/search-bar.component";
-  import {StoreDevtoolsModule} from "@ngrx/store-devtools";
-  import {reducer} from "../reducers/index";
-  import {StoreModule} from "@ngrx/store";
-  import {JsonpModule, HttpModule} from "@angular/http";
-  import {FormsModule} from "@angular/forms";
-  import {CommonModule} from "@angular/common";
-  import {BrowserModule} from "@angular/platform-browser";
-  import {RouterTestingModule} from "@angular/router/testing";
+import {AutocompleteService} from "../autocomplete.service";
+import {RelatedSearchComponent} from "../related-search/related-search.component";
+import {InfoboxComponent} from "../infobox/infobox.component";
+import {ModalComponent} from "ng2-bs3-modal/components/modal";
+import {ContactComponent} from "../contact/contact.component";
+import {AboutComponent} from "../about/about.component";
+import {FooterNavbarComponent} from "../footer-navbar/footer-navbar.component";
+import {AppComponent} from "../app.component";
+import {NavbarComponent} from "../navbar/navbar.component";
+import {IndexComponent} from "../index/index.component";
+import {ResultsComponent} from "../results/results.component";
+import {NotFoundComponent} from "../not-found/not-found.component";
+import {AdvancedsearchComponent} from "../advancedsearch/advancedsearch.component";
+import {SearchBarComponent} from "../search-bar/search-bar.component";
+import {StoreDevtoolsModule} from "@ngrx/store-devtools";
+import {reducer} from "../reducers/index";
+import {StoreModule} from "@ngrx/store";
+import {JsonpModule, HttpModule} from "@angular/http";
+import {FormsModule} from "@angular/forms";
+import {CommonModule} from "@angular/common";
+import {BrowserModule} from "@angular/platform-browser";
+import {RouterTestingModule} from "@angular/router/testing";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('AutoCompleteComponent', () => {
   let component: AutoCompleteComponent;
@@ -55,6 +56,7 @@ describe('AutoCompleteComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
       providers: [
        AutocompleteService ]

--- a/src/app/contact/contact.component.spec.ts
+++ b/src/app/contact/contact.component.spec.ts
@@ -22,6 +22,7 @@ import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('ContactComponent', () => {
   let component: ContactComponent;
@@ -54,6 +55,7 @@ describe('ContactComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
 
       ]
     })

--- a/src/app/footer-navbar/footer-navbar.component.spec.ts
+++ b/src/app/footer-navbar/footer-navbar.component.spec.ts
@@ -23,6 +23,7 @@ import { ContactComponent } from '../contact/contact.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('FooterNavbarComponent', () => {
   let component: FooterNavbarComponent;
@@ -55,6 +56,7 @@ describe('FooterNavbarComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ]
     })
       .compileComponents();

--- a/src/app/index/index.component.spec.ts
+++ b/src/app/index/index.component.spec.ts
@@ -25,6 +25,8 @@ import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutocompleteService} from "../autocomplete.service";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
+import { ThemeService } from '../theme.service';
 
 describe('IndexComponent', () => {
   let component: IndexComponent;
@@ -57,9 +59,11 @@ describe('IndexComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
       providers: [
-        AutocompleteService
+        AutocompleteService,
+        ThemeService
       ],
     })
       .compileComponents();

--- a/src/app/infobox/infobox.component.spec.ts
+++ b/src/app/infobox/infobox.component.spec.ts
@@ -23,6 +23,7 @@ import {StoreModule} from "@ngrx/store";
 import {StoreDevtoolsModule} from "@ngrx/store-devtools";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('InfoboxComponent', () => {
   let component: InfoboxComponent;
@@ -55,6 +56,7 @@ describe('InfoboxComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
       providers: [
         KnowledgeapiService

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -25,6 +25,7 @@ import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 import {AutocompleteService} from "../autocomplete.service";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
@@ -57,6 +58,7 @@ describe('NavbarComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
       providers: [
         AutocompleteService,

--- a/src/app/not-found/not-found.component.spec.ts
+++ b/src/app/not-found/not-found.component.spec.ts
@@ -25,6 +25,7 @@ import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 import {AutocompleteService} from "../autocomplete.service";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('NotFoundComponent', () => {
   let component: NotFoundComponent;
@@ -57,6 +58,7 @@ describe('NotFoundComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
       providers: [
         AutocompleteService

--- a/src/app/related-search/related-search.component.spec.ts
+++ b/src/app/related-search/related-search.component.spec.ts
@@ -25,6 +25,7 @@ import { RelatedSearchComponent } from './related-search.component';
 import {KnowledgeapiService} from "../knowledgeapi.service";
 import {AutocompleteService} from "../autocomplete.service";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('RelatedSearchComponent', () => {
   let component: RelatedSearchComponent;
@@ -57,6 +58,7 @@ describe('RelatedSearchComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
       providers: [
         KnowledgeapiService

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -12,7 +12,8 @@
                 <ul class="dropdown-menu" aria-labelledby="tools" id="tool-dropdown">
                     <li (click)="filterByContext()">Context Ranking</li>
                     <li (click)="filterByDate()">Sort by Date</li>
-                    <li data-toggle="modal" data-target="#myModal" (click)="advancedsearch()">Advanced Search</li>
+                    <li data-toggle="modal" data-target="#myModal">Advanced Search</li>
+                    <li data-toggle="modal" data-target="#customization">Customization</li>
                 </ul>
             </li>
         </ul>
@@ -27,13 +28,13 @@
     <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
-                    <a class="title-pointer" href="{{item.link}}">{{item.title}}</a>
+                    <a class="title-pointer" href="{{item.link}}" [style.color]="themeService.titleColor">{{item.title}}</a>
                 </div>
                 <div class="link">
-                    <p>{{item.link}}</p>
+                    <p [style.color]="themeService.linkColor">{{item.link}}</p>
                 </div>
                 <div class="description">
-                    <p>{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
+                    <p [style.color]="themeService.descriptionColor">{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
                 </div>
             </div>
       <app-related-search [hidden]="hidefooter"></app-related-search>
@@ -81,6 +82,9 @@
         </div>
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <app-advancedsearch></app-advancedsearch>
+</div>
+<div class="modal fade" id="customization" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <app-theme></app-theme>
 </div>
 
 <!--footer navigation bar goes here-->

--- a/src/app/results/results.component.spec.ts
+++ b/src/app/results/results.component.spec.ts
@@ -27,6 +27,8 @@ import {KnowledgeapiService} from "../knowledgeapi.service";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
 import {AutocompleteService} from "../autocomplete.service";
+import { ThemeComponent } from '../theme/theme.component';
+import { ThemeService } from '../theme.service';
 
 describe('ResultsComponent', () => {
   let component: ResultsComponent;
@@ -59,8 +61,9 @@ describe('ResultsComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
-      providers: [SearchService, KnowledgeapiService, AutocompleteService]
+      providers: [SearchService, KnowledgeapiService, AutocompleteService, ThemeService]
     })
       .compileComponents();
   }));

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { SearchService } from '../search.service';
+import { ThemeService } from '../theme.service';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import * as fromRoot from '../reducers';
@@ -109,7 +110,7 @@ export class ResultsComponent implements OnInit {
   }
 
   constructor(private searchservice: SearchService, private route: Router, private activatedroute: ActivatedRoute,
-              private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
+              private store: Store<fromRoot.State>, private ref: ChangeDetectorRef, public themeService: ThemeService) {
 
     this.activatedroute.queryParams.subscribe(query => {
       this.hidefooter = 1;

--- a/src/app/search-bar/search-bar.component.spec.ts
+++ b/src/app/search-bar/search-bar.component.spec.ts
@@ -25,6 +25,7 @@ import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutocompleteService} from "../autocomplete.service";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('SearchBarComponent', () => {
   let component: SearchBarComponent;
@@ -58,6 +59,7 @@ describe('SearchBarComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ],
       providers: [
         AutocompleteService

--- a/src/app/terms/terms.component.spec.ts
+++ b/src/app/terms/terms.component.spec.ts
@@ -22,6 +22,7 @@ import { TermsComponent } from './terms.component';
 import {InfoboxComponent} from "../infobox/infobox.component";
 import {RelatedSearchComponent} from "../related-search/related-search.component";
 import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
+import { ThemeComponent } from '../theme/theme.component';
 
 describe('TermsComponent', () => {
   let component: TermsComponent;
@@ -53,6 +54,7 @@ describe('TermsComponent', () => {
         InfoboxComponent,
         RelatedSearchComponent,
         AutoCompleteComponent,
+        ThemeComponent
       ]
     })
     .compileComponents();

--- a/src/app/theme.service.spec.ts
+++ b/src/app/theme.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ThemeService]
+    });
+  });
+
+  it('should be created', inject([ThemeService], (service: ThemeService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/theme.service.ts
+++ b/src/app/theme.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ThemeService {
+
+  public titleColor: string;
+  public linkColor: string;
+  public descriptionColor: string;
+
+  constructor() { }
+
+}

--- a/src/app/theme/theme.component.html
+++ b/src/app/theme/theme.component.html
@@ -1,0 +1,12 @@
+<div class="modal-dialog" role="document">
+  <div class="modal-content">
+    <div class="modal-header">
+      <!-- Start ignoring HTMLLintBear -->
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <!-- Stop ignoring HTMLLintBear -->
+      <h4 class="modal-title" id="my-modal-label">Customization</h4>
+      <button type="button" (click)="darkTheme()" class="theme-link">Dark Theme</button>
+      <button type="button" (click)="defaultTheme()" class="theme-link">Default Theme</button>
+    </div>
+  </div>
+</div>

--- a/src/app/theme/theme.component.spec.ts
+++ b/src/app/theme/theme.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ThemeComponent } from './theme.component';
+import { ThemeService } from '../theme.service';
+
+describe('ThemeComponent', () => {
+  let component: ThemeComponent;
+  let fixture: ComponentFixture<ThemeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ThemeComponent
+      ],
+      providers: [
+        ThemeService
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ThemeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/theme/theme.component.ts
+++ b/src/app/theme/theme.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { ThemeService } from '../theme.service';
+
+@Component({
+  selector: 'app-theme',
+  templateUrl: './theme.component.html',
+  styleUrls: ['./theme.component.css']
+})
+export class ThemeComponent implements OnInit {
+
+  constructor(
+    private themeService: ThemeService
+  ) { }
+
+  ngOnInit() {
+  }
+
+  darkTheme() {
+    this.themeService.titleColor = '#050404';
+    this.themeService.linkColor = '#7E716E';
+    this.themeService.descriptionColor = '#494443';
+  }
+
+  defaultTheme() {
+    this.themeService.titleColor = '#1a0dab';
+    this.themeService.linkColor = '#006621';
+    this.themeService.descriptionColor = '#545454';
+  }
+
+}


### PR DESCRIPTION
Addresses #269 

Preview link- <a href="https://harshit98.github.io/susper.com/">here</a>.

Due to recent addition of `autocomplete component` , #349 was failing travis test.

Things done in this PR -
- Provided a simple theme for susper. We can start adding up themes to Susper from this step.
- Did corrections in indentation of code.

Go `Tools` -> `Customization`. It will open up a modal and user can choose a desired theme. I have not much worked on theme. It will just change colour of title and description in the results section.

UPDATE : 
Kindly hide the suggestion box over `Tools` to check the customisation feature. 