### PR TITLE
Fixes #314 Remove 'Add Search provider' feature from Chrome

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="search" href="//susper.com/susper.xml" type="application/opensearchdescription+xml" title="susper.com"/>
 </head>
 <body>
 <!--<div id="set-susper-default">
@@ -30,13 +31,13 @@
 -->
 <script>
   $(document).ready(function () {
-    //var isFirefox = typeof InstallTrigger !== 'undefined';
+    var isFirefox = typeof InstallTrigger !== 'undefined';
 
-    //if (isFirefox === false) {
-    //    $("#set-susper-default").remove();
-    //    $(".input-group-btn").addClass("align-search-btn");
-    //    $("#navbar-search").addClass("align-navsearch-btn");
-    //}
+    if (isFirefox === false) {
+        $("#set-susper-default").remove();
+        $(".input-group-btn").addClass("align-search-btn");
+        $("#navbar-search").addClass("align-navsearch-btn");
+    }
 
     if (window.external && window.external.IsSearchProviderInstalled) {
         var isInstalled = window.external.IsSearchProviderInstalled("http://susper.com");


### PR DESCRIPTION
Closes #314 

Preview link <a href="https://harshit98.github.io/susper.com/">here</a>.

Things done in this PR : 
- Removed 'add search provider feature' from Chrome browser. However for firefox, it is still there.
- For Chrome browser, this feature we'll be adding in tutorials section similar to duckduckgo - https://duckduckgo.com/install?t=hc becuase Chrome has some different feature to add search provider. I'll open up an issue for this. Catch up more discussion here - <a href="https://github.com/fossasia/susper.com/issues/314#issuecomment-304097232">discussion</a>.
- I have added the opensearch link following http://blog.unto.net/add-opensearch-to-your-site-in-five-minutes.html which will detect the search engine like this - 

![screenshot from 2017-05-26 00-02-56](https://cloud.githubusercontent.com/assets/22245418/26522291/b4b76948-431a-11e7-88c3-09186e0a3f30.png)
