### PR TITLE
Fixes #388, #399 Related searches now show number of results and pages

### DIFF
--- a/src/app/related-search/related-search.component.html
+++ b/src/app/related-search/related-search.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="results?.length > 0" class="card">
     <h3>Searches related to {{this.keyword}}</h3>
     <div *ngFor="let result of results" class="related">
-      <a [routerLink]="resultsearch" [queryParams]="{query: result.label}" class="rellink">{{result.label}}</a>
+      <a [routerLink]="resultsearch" [queryParams]="getQuery(result.label)" class="rellink">{{result.label}}</a>
     </div>
   </div>
 

--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -52,7 +52,18 @@ export class RelatedSearchComponent implements OnInit {
       }
     });
   }
-
+  getQuery(q) {
+    return {query: q.toString(),
+      verify: false,
+      nav: 'filetype,protocol,hosts,authors,collections,namespace,topics,date',
+      start: 0,
+      indexof: 'off',
+      meanCount: '5',
+      resource: 'global',
+      prefermaskfilter: '',
+      rows: 10,
+      timezoneOffset: 0};
+  }
   ngOnInit() {
   }
 


### PR DESCRIPTION
Fixes #388, #399
 Related searches now show number of results and pages
![image](https://cloud.githubusercontent.com/assets/20185076/26630843/1ec49ff0-4626-11e7-9fb0-4aeff37b0073.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26630762/d1e6986e-4625-11e7-9e3d-3129211a6fa9.png)

[Demo link](https://marauderer97.github.io/susper.com/)