### PR TITLE
Fixes #395, infobox links now give no errors in result count or pagination bar

### DIFF
--- a/src/app/infobox/infobox.component.html
+++ b/src/app/infobox/infobox.component.html
@@ -7,7 +7,7 @@
   <h3><b>Related Searches</b></h3>
 
   <div *ngFor="let result of results">
-    <a [routerLink]="resultsearch" [queryParams]="{query: result.label}">{{result.label}}</a>
+    <a [routerLink]="resultsearch" [queryParams]="getQuery(result.label)">{{result.label}}</a>
   </div>
   </div>
 </div>

--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -47,7 +47,18 @@ export class InfoboxComponent implements OnInit {
       }
     });
   }
-
+  getQuery(q) {
+    return {query: q.toString(),
+      verify: false,
+      nav: 'filetype,protocol,hosts,authors,collections,namespace,topics,date',
+      start: 0,
+      indexof: 'off',
+      meanCount: '5',
+      resource: 'global',
+      prefermaskfilter: '',
+      rows: 10,
+      timezoneOffset: 0};
+  }
   ngOnInit() {
   }
 


### PR DESCRIPTION
Fixes #395, infobox links now gives a proper pagination bar, and result count
![image](https://cloud.githubusercontent.com/assets/20185076/26631137/59410672-4627-11e7-8067-f6d22d9d6adf.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26631112/36252eac-4627-11e7-8a1f-4033f5d86f63.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26631119/3fc807b8-4627-11e7-8dfc-79489d7ac319.png)
[Demo link
](https://marauderer97.github.io/susper.com/)