### PR TITLE
Fixes #393, The search-result page will be loaded only on entering query

### DIFF
--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -62,7 +62,9 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
     this.vc.first.nativeElement.focus();
   }
   submit() {
-    this.router.navigate(['/search'], { queryParams: this.searchdata });
+    if (this.searchdata.query.toString().length !== 0) {
+      this.router.navigate(['/search'], {queryParams: this.searchdata});
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #393, 
The search-result page will be loaded only on entering query
Screenshots(not applicable)
[Demo link](https://marauderer97.github.io/susper.com/)