### PR TITLE
Fixes #378, Search bar at center of page for all sizes, made responsive

### DIFF
--- a/src/app/index/index.component.css
+++ b/src/app/index/index.component.css
@@ -3,8 +3,10 @@
 }
 
 #search-bar{
-  position: absolute;
-  left: 28%;
+  position: fixed;
+  left: 50%;
+  margin-left: -275px;
+
 }
 
 .footer-fixed{

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -92,26 +92,13 @@
   }
 }
 
-@media screen and (min-width: 1920px) {
-  #nav-group {
-    left: 65%;
-  }
-}
-
 @media screen and (max-width: 968px) {
-  #nav-group {
-    left: -12%;
-  }
   #nav-input {
     width: 50vw;
   }
 }
 
 @media screen and (max-width: 767px) {
-  #nav-group {
-    left: -22%;
-    width: 20px;
-  }
   #nav-input {
     width: 80vw;
   }


### PR DESCRIPTION


Fixes issue #378 

Changes: Makes search bar position responsive, for all screen sizes

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
AT size 1920x900
![screen shot 2017-06-03 at 19 18 25](https://cloud.githubusercontent.com/assets/20185076/26754107/befa26ee-4891-11e7-9dc7-820c17ed5a15.png)

![image](https://cloud.githubusercontent.com/assets/20185076/26754093/7e1c6042-4891-11e7-8625-a635e60da1e0.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26754095/87929eac-4891-11e7-8051-aac3cd96b0ba.png)
![image](https://cloud.githubusercontent.com/assets/20185076/26754098/9082624a-4891-11e7-9e39-2ebc285b7785.png)
