### PR TITLE
Fixes #422, errors in console fixed for Knowledge API service results

### DIFF
--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -30,7 +30,7 @@ export class InfoboxComponent implements OnInit {
     this.query$.subscribe( query => {
       if (query) {
         this.knowledgeservice.getsearchresults(query).subscribe(res => {
-          if (res.results) {
+          if (res.results[0]) {
             if (res.results[0].label.toLowerCase().includes(query.toLowerCase())) {
               this.initialresults = res.results;
             } else {

--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -32,7 +32,7 @@ export class RelatedSearchComponent implements OnInit {
     this.query$.subscribe( query => {
       if (query) {
         this.knowledgeservice.getsearchresults(query).subscribe(res => {
-          if (res.results) {
+          if (res.results[0]) {
             if (!res.results[0].label.toLowerCase().localeCompare(query.toLowerCase())) {
               res.results.splice(0, 1);
               this.initialresults = res.results;


### PR DESCRIPTION
Fixes issue #422 

Changes: Fixes errors appearing in the console from Knowledge  API service when no results are found
In the initial code we only checked if results were defined, but they always were defined even if empty 
Eg results ={}, but results[0] was undefined. Hence the code change was made.


Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
Before
![image](https://cloud.githubusercontent.com/assets/20185076/26818787/b350a14a-4ab9-11e7-95b1-b6e0a74d6137.png)
After
![image](https://cloud.githubusercontent.com/assets/20185076/26818942/59b975d4-4aba-11e7-96ef-143d6d87c32e.png)