### PR TITLE
Fixes #410 changes auto complete API to Yacy from dbpedia prefix API

### DIFF
--- a/src/app/auto-complete/auto-complete.component.html
+++ b/src/app/auto-complete/auto-complete.component.html
@@ -1,5 +1,5 @@
-<div class="suggestion-box" *ngIf="results.length > 0">
+<div class="suggestion-box" *ngIf="results">
   <div *ngFor="let result of results">
-    <a [routerLink]="resultsearch" [queryParams]="{query: result.label}" class="suggestions">{{result.label}}</a>
+    <a [routerLink]="resultsearch" [queryParams]="{query: result}" class="suggestions">{{result}}</a>
   </div>
 </div>

--- a/src/app/auto-complete/auto-complete.component.ts
+++ b/src/app/auto-complete/auto-complete.component.ts
@@ -3,7 +3,6 @@ import {AutocompleteService} from "../autocomplete.service";
 import {Router, ActivatedRoute} from "@angular/router";
 import {Store} from "@ngrx/store";
 import * as fromRoot from '../reducers';
-import {KnowledgeapiService} from "../knowledgeapi.service";
 
 @Component({
   selector: 'app-auto-complete',
@@ -22,8 +21,13 @@ export class AutoCompleteComponent implements OnInit {
     this.query$.subscribe( query => {
       if (query) {
         this.autocompleteservice.getsearchresults(query).subscribe(res => {
-          if (res.results) {
-            this.results = res.results;
+          if (res[0]) {
+            // console.log(res[1]);
+            this.results = res[1];
+            this.results.concat(res[0]);
+            if ( this.results.length > 5) {
+            this.results = this.results.splice (0, 5);
+            }
           } else {
             this.results = [];
           }

--- a/src/app/autocomplete.service.ts
+++ b/src/app/autocomplete.service.ts
@@ -11,8 +11,8 @@ import * as fromRoot from './reducers';
 
 @Injectable()
 export class AutocompleteService {
-  server = 'http://lookup.dbpedia.org';
-  searchURL = this.server + '/api/search/PrefixSearch?';
+  server = 'yacy.searchlab.eu';
+  suggestUrl = 'http://' + this.server + '/suggest.json?callback=?';
   homepage = 'http://susper.com';
   logo = '../images/susper.svg';
   constructor(private http: Http, private jsonp: Jsonp, private store: Store<fromRoot.State>) {
@@ -20,15 +20,24 @@ export class AutocompleteService {
   getsearchresults(searchquery) {
 
     let params = new URLSearchParams();
-    params.set('QueryString', searchquery);
+    params.set('q', searchquery);
    // params.set('QueryClass', 'MaxHits=5');
 
+    params.set('wt', 'yjson');
+    params.set('callback', 'JSONP_CALLBACK');
+
+    params.set('facet', 'true');
+    params.set('facet.mincount', '1');
+    params.append('facet.field', 'host_s');
+    params.append('facet.field', 'url_protocol_s');
+    params.append('facet.field', 'author_sxt');
+    params.append('facet.field', 'collection_sxt');
     let headers = new Headers({ 'Accept': 'application/json' });
     let options = new RequestOptions({ headers: headers, search: params });
-    return this.http
-      .get(this.searchURL, options).map(res =>
+    return this.jsonp
+      .get('http://yacy.searchlab.eu/suggest.json', {search: params}).map(res =>
 
-        res.json()
+        res.json()[0]
 
       ).catch(this.handleError);
 


### PR DESCRIPTION

Fixes issue #410 

Changes: Dbpedia's Prefix API has been replaced by that of Yacy Suggest API

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
![image](https://cloud.githubusercontent.com/assets/20185076/26823446/481e8a7e-4acb-11e7-844b-5fe3a8ad79ee.png)

![image](https://cloud.githubusercontent.com/assets/20185076/26823380/0c25e7ba-4acb-11e7-87e1-56487c244979.png)

