### PR TITLE
Fixes #385 Match the results width exact with search bar's width

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -42,7 +42,7 @@ a {
 }
 
 .feed {
-  width: 670px;
+  width: 49%;
 }
 
 .title-pointer:hover {
@@ -256,9 +256,24 @@ a {
   }
 }
 
+@media screen and (max-width: 1440px) {
+  .feed {
+    width: 43%;
+  }
+}
+
 @media screen and (max-width:1365px) {
   #tools {
     margin-left: 16%;
+  }
+  .feed {
+    width: 49%;
+  }
+}
+
+@media screen and (max-width:1175px) {
+  .feed {
+    width: 56%;
   }
 }
 
@@ -319,6 +334,12 @@ a {
   }
 }
 
+@media screen and (max-width:950px) {
+  .feed {
+    width: 66.3%;
+  }
+}
+
 @media screen and (max-width:882px) {
   #search-options {
     margin-left: 9.8%;
@@ -328,6 +349,9 @@ a {
   }
   .result {
     margin-left: 7.7%;
+  }
+  .feed {
+    width: 77%;
   }
 }
 
@@ -364,6 +388,9 @@ a {
   }
   .result {
     margin-left: 13.5%;
+  }
+  .feed {
+    width: 87%;
   }
 }
 


### PR DESCRIPTION
Fixes issue #385 

Changes:
- Now the result's section width matches to search bar's width. It will not cross the width of search bar now.

Demo Link: <a href="https://harshit98.github.io/susper.com/">here</a>

Screenshots for the change: 

![screenshot from 2017-06-07 03-37-52](https://user-images.githubusercontent.com/22245418/26854251-f7f2e320-4b32-11e7-94df-cbdda64d4bd6.png)

Kindly review @nikhilrayaprolu @Marauderer97 :)