### PR TITLE
Fixes #422, errors in console fixed for Knowledge effect results

### DIFF
--- a/src/app/effects/knowledge.ts
+++ b/src/app/effects/knowledge.ts
@@ -57,13 +57,18 @@ export class KnowledgeEffects {
         .takeUntil(nextSearch$)
         .subscribe((response) => {
         if (response.results) {
-          if (response.results[0].label.toLowerCase().includes(querypay.query.toLowerCase())) {
-            this.store.dispatch(new knowledge.SearchAction(response));
-            return empty();
+          if(response.results[0]){
+            if (response.results[0].label.toLowerCase().includes(querypay.query.toLowerCase())) {
+              this.store.dispatch(new knowledge.SearchAction(response));
+              return empty();
+            } else {
+              this.store.dispatch(new knowledge.SearchAction([]));
+              return empty();
+            }
           } else {
             this.store.dispatch(new knowledge.SearchAction([]));
-            return empty();
           }
+
         } else {
           this.store.dispatch(new knowledge.SearchAction([]));
         }

--- a/src/app/effects/knowledge.ts
+++ b/src/app/effects/knowledge.ts
@@ -57,7 +57,7 @@ export class KnowledgeEffects {
         .takeUntil(nextSearch$)
         .subscribe((response) => {
         if (response.results) {
-          if(response.results[0]){
+          if (response.results[0]) {
             if (response.results[0].label.toLowerCase().includes(querypay.query.toLowerCase())) {
               this.store.dispatch(new knowledge.SearchAction(response));
               return empty();


### PR DESCRIPTION
Fixes issue #422 

Changes: Fixes errors appearing in the console from Knowledge effects when no results are found

Demo Link: https://nikhilrayaprolu.github.io/susper.com-1/

Screenshots for the change: 
before:-
![image](https://user-images.githubusercontent.com/15216503/26877074-60ece95c-4ba6-11e7-9117-e6771eb4259e.png)

after:-
![image](https://user-images.githubusercontent.com/15216503/26877042-4e6f8640-4ba6-11e7-83d2-789c1650d68d.png)
