### PR TITLE
Fixes #443, advanced search changed more like market leader

### DIFF
--- a/src/app/newadvancedsearch/newadvancedsearch.component.css
+++ b/src/app/newadvancedsearch/newadvancedsearch.component.css
@@ -3,6 +3,29 @@
     text-align: right;
   }
 }
+
+#top-line{
+  margin-bottom: 48px;
+  width: 200%;
+  margin-left: -5.5%;
+}
+
+.label-heading{
+  max-width: 23%;
+}
+.label-search{
+  cursor: default;
+  font-weight: 300;
+}
+.container{
+  padding-left: 3.5%;
+  float: left;
+  width: 70%;
+}
+.form-control{
+  width: 135%;
+  border-radius: 0px;
+}
 .navbar-nav > li > a{
   text-align: left;
 }

--- a/src/app/newadvancedsearch/newadvancedsearch.component.html
+++ b/src/app/newadvancedsearch/newadvancedsearch.component.html
@@ -25,8 +25,8 @@
 
 <div class="container">
   <h3 class="advanced-search-heading">Advanced Search</h3>
-  <hr>
-    <h3>Find pages with...</h3>
+  <hr id="top-line">
+    <h3 class="label-heading">Find pages with...</h3>
     <form>
       <div class="row">
         <div class="form-group">
@@ -59,7 +59,7 @@
     </form>
   <hr>
 
-    <h3>Then narrow your results by...</h3>
+    <h3  class="label-heading">Then narrow your results by...</h3>
     <form>
       <div class="row">
       <div class="form-group">


### PR DESCRIPTION
Fixes issue #443 

Changes: The following changes need to be made to susper's advanced search. 

- [x] Added extra padding before the start of the form following market leader

- [x] Changed appearance of certain labels, made them flow into the next line 

- [x] Made input box labels darker


Demo Link: [Here](https://marauderer97.github.io/susper.com)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/26915518-f37c0148-4c43-11e7-9c93-fdd6f974b809.png)
![image](https://user-images.githubusercontent.com/20185076/26915526-ff1631ae-4c43-11e7-95be-28f53df95ae5.png)
