### PR TITLE
Fixes #455, advanced search is properly linked

### DIFF
--- a/src/app/newadvancedsearch/newadvancedsearch.component.html
+++ b/src/app/newadvancedsearch/newadvancedsearch.component.html
@@ -7,7 +7,7 @@
         <span class = "icon-bar"></span>
         <span class = "icon-bar"></span>
       </button>
-      <a class="navbar-brand advsearch-navbar" href="//susper.com">
+      <a class="navbar-brand advsearch-navbar" routerLink="/">
         <img alt="brand" class="navbar-logo" src="../../assets/images/susper.svg">
       </a>
     </div>


### PR DESCRIPTION
Fixes issue #455 
Changes:
router link is used to link susper brand icon in advanced search.

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
Not applicable