### PR TITLE
Fixes #458, changes link styling in About page

### DIFF
--- a/src/app/about/about.component.css
+++ b/src/app/about/about.component.css
@@ -12,6 +12,11 @@
   text-align: left;
 }
 
+.page-link{
+  padding-right: 0%;
+  color: #1a0dab;
+}
+
 .navbar-right{
   border-top:none;
 }

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -38,17 +38,17 @@
             <div class="col-lg-4 col-sm-12 sub-details">
                 <h5 class="bold">About YaCy</h5>
                 <p>YaCy is a free search engine that anyone can use to build a search portal for their intranet or to help search
-                    the public internet. Read more about YaCy here - <a href="https://yacy.net/en/index.html" target="_blank">YaCy Decentralized Web Search</a></p>
+                    the public internet. Read more about YaCy here - <a class="page-link" href="https://yacy.net/en/index.html" target="_blank">YaCy Decentralized Web Search</a></p>
             </div>
             <div class="col-lg-4 col-sm-12 sub-details">
                 <h5 class="bold">Communication</h5>
-                <p>Facing issues while setting up project on local environment? Our chat channel is on gitter here: <a href="https://gitter.im/fossasia/susper.com"
-                        target="_blank">fossasia/susper.com</a> We'll be happy to help you out!'</p>
+                <p>Facing issues while setting up project on local environment? Our chat channel is on gitter here: <a class="page-link" href="https://gitter.im/fossasia/susper.com"
+                        target="_blank">fossasia/susper.com</a>. We'll be happy to help you out!'</p>
             </div>
             <div class="col-lg-4 col-sm-12 sub-details">
                 <h5 class="bold">Contribute to our project</h5>
                 <p>Get involved as an Open Source developer, designer or tester and start your adventure today! Solve an issue
-                    or feature request on our repositories with <a href="https://github.com/fossasia/susper.com" target="_blank">FOSSASIA</a>Build
+                    or feature request on our repositories with <a class="page-link" href="https://github.com/fossasia/susper.com" target="_blank">FOSSASIA</a>. Build
                     up your developer profile and become part of a fantastic community.</p>
             </div>
         </div>
@@ -62,7 +62,7 @@
         </div>
         <div class="row">
             <div class="col-lg-12 col-sm-12 contact-sub-details">
-                <p>If you would like to get in touch with us, you find our details on the <a routerLink="/contact">contact page.</a></p>
+                <p>If you would like to get in touch with us, you find our details on the <a class="page-link" routerLink="/contact">contact page.</a></p>
             </div>
 
         </div>


### PR DESCRIPTION
Fixes issue #458 

Changes:
Made links in about page blue, and removed the padding to the right

Demo Link: [here](https://marauderer97.github.io/susper.com/)

Screenshots for the change:
Before
![image](https://user-images.githubusercontent.com/20185076/26949936-8bc18192-4cb9-11e7-872d-6a10cfca7cf3.png)
 
After
![image](https://user-images.githubusercontent.com/20185076/26949902-677be17e-4cb9-11e7-9029-623fa31f9f3d.png)
