### PR TITLE
Fixes #457, blinking cursor hidden on hitting enter

### DIFF
--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -42,6 +42,7 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
   hidebox(event: any) {
     if (event.which === 13) {
       this.displayStatus = 'hidebox';
+      event.target.blur();
     }
   }
   hidesuggestions(data: number) {


### PR DESCRIPTION
Fixes issue #457 

Changes: Blinking cursor is hidden when enter is pressed.

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/26965067-d378a9cc-4d11-11e7-8122-80ebb0c47735.png)

@nikhilrayaprolu @harshit98 @sandeepm96 @isuruAb Please review
