### PR TITLE
Fixes #464, Images are being displayed

### DIFF
--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -81,7 +81,7 @@ export class ResultsComponent implements OnInit {
   }
 
   imageClick() {
-    this.getPresentPage(0);
+    this.getPresentPage(1);
     this.resultDisplay = 'images';
     this.searchdata.rows = 100;
     this.searchdata.fq = 'url_file_ext_s:(png+OR+jpeg+OR+jpg+OR+gif)';


### PR DESCRIPTION
Fixes issue #464 

Changes: Images are being displayed in Susper.

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/26968985-bdc1e2b4-4d21-11e7-8df0-f368760064e2.png)
