### PR TITLE
Fixes #462, width and position of Infobox more like market leader

### DIFF
--- a/src/app/infobox/infobox.component.css
+++ b/src/app/infobox/infobox.component.css
@@ -5,8 +5,9 @@
   margin-bottom: 16px;
   padding: 22px 22px 18px 22px;
   transition: 0.3s;
-  width: 100%;
-  margin-left: 20px;
+  width: 434px;
+  margin-left: 11%;
+  margin-top: 3%;
 }
 
 /* Add some padding inside the card container */
@@ -39,7 +40,17 @@ a {
 }
 
 /** Screen Responsiveness **/
-@media screen and (max-width: 1143px) {
+@media screen and (max-width: 1280px) {
+  .card{
+    width: 368px;
+  }
+}
+@media screen and (max-width: 1180px) {
+  .card{
+    width: 268px;
+  }
+}
+  @media screen and (max-width: 998px) {
   .card {
     display: none;
   }


### PR DESCRIPTION
Fixes issue #462 

Changes: This Pr does the following 

- [x] reduces the width of the info box to follow market leader

- [x] increases the margin of the info box at the top to follow the market leader

- [x] Shifts the position of the infobox so that the right margin remains the same even after reducing the width of the info box



Demo Link:[Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/20185076/26971477-f0f6cf7e-4d2a-11e7-8921-e5d749b8cd91.png)

![image](https://user-images.githubusercontent.com/20185076/26971455-e33676a0-4d2a-11e7-958f-2c897ab20dd8.png)

