### PR TITLE
Fixes #449, related searches are displayed independently

### DIFF
--- a/src/app/effects/knowledge.ts
+++ b/src/app/effects/knowledge.ts
@@ -58,13 +58,8 @@ export class KnowledgeEffects {
         .subscribe((response) => {
         if (response.results) {
           if (response.results[0]) {
-            if (response.results[0].label.toLowerCase().includes(querypay.query.toLowerCase())) {
               this.store.dispatch(new knowledge.SearchAction(response));
               return empty();
-            } else {
-              this.store.dispatch(new knowledge.SearchAction([]));
-              return empty();
-            }
           } else {
             this.store.dispatch(new knowledge.SearchAction([]));
           }

--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -13,6 +13,7 @@ import {Observable} from "rxjs";
 export class InfoboxComponent implements OnInit {
   results: Array<any>;
   query$: any;
+  keyword: any;
   resultsearch = '/search';
   initialresults: Array<any>;
   resultscomponentchange$: Observable<any>;
@@ -20,13 +21,27 @@ export class InfoboxComponent implements OnInit {
   constructor(private knowledgeservice: KnowledgeapiService, private route: Router, private activatedroute: ActivatedRoute,
               private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
     this.query$ = store.select(fromRoot.getquery);
+    this.query$.subscribe(query => {
+      this.keyword = query;
+    });
     this.resultscomponentchange$ = store.select(fromRoot.getItems);
     this.resultscomponentchange$.subscribe(res => {
       this.results = this.initialresults;
     });
     this.response$ = store.select(fromRoot.getKnowledge);
+    this.initialresults = [];
     this.response$.subscribe(res => {
-      this.initialresults = res.results || [];
+      if (res.results) {
+        if (res.results[0]) {
+          if (res.results[0].label.toLowerCase().includes(this.keyword.toLowerCase())) {
+            this.initialresults = res.results;
+          } else {
+              this.initialresults = [];
+            }
+        }
+      } else {
+          this.initialresults = [];
+        }
 
     });
 

--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -25,6 +25,7 @@ export class RelatedSearchComponent implements OnInit {
     this.query$.subscribe(query => {
       this.keyword = query;
     });
+    this.results = [];
     this.resultscomponentchange$ = store.select(fromRoot.getItems);
     this.resultscomponentchange$.subscribe(res => {
       this.results = this.initialresults;


### PR DESCRIPTION

Fixes issue #449 

Changes: Irrespective of whether infobox should be displayed, the related searches are displayed at the bottom of the page.

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/27038619-2772a3a4-4fa9-11e7-9eff-657c66a42636.png)

![image](https://user-images.githubusercontent.com/20185076/27038652-3bbcd334-4fa9-11e7-99e2-9485d146f60b.png)
