### PR TITLE
Fixes #466 infobox appears now when search is fired

### DIFF
--- a/src/app/reducers/index.ts
+++ b/src/app/reducers/index.ts
@@ -83,3 +83,4 @@ export const getNavigation = createSelector(getSearchState, fromSearch.getNaviga
 export const getquery = createSelector(getQueryState, fromQuery.getpresentquery);
 export const getwholequery = createSelector(getQueryState, fromQuery.getpresentwholequery);
 export const getKnowledge = createSelector(getKnowledgeState, fromKnowledge.getresponse);
+export const getResponseTime = createSelector(getSearchState, fromSearch.getresponsetime);

--- a/src/app/reducers/search.ts
+++ b/src/app/reducers/search.ts
@@ -9,6 +9,7 @@ export interface State {
   items: any;
   totalResults: any;
   navigation: any;
+  responsetime: any;
 }
 /**
  * There is always a need of initial state to be passed onto the store.
@@ -20,7 +21,8 @@ const initialState: State = {
   searchresults: {},
   items: [],
   totalResults: 0,
-  navigation: []
+  navigation: [],
+  responsetime: 0
 };
 export function reducer(state: State = initialState, action: search.Actions): State {
   switch (action.type) {
@@ -31,6 +33,7 @@ export function reducer(state: State = initialState, action: search.Actions): St
         items: search.channels[0].items,
         totalResults: Number(search.channels[0].totalResults) || 0,
         navigation: search.channels[0].navigation,
+        responsetime: new Date()
       });
     }
     default: {
@@ -42,6 +45,6 @@ export const getsearchresults = (state: State) => state.searchresults;
 export const getItems = (state: State) => state.items;
 
 export const getTotalResults = (state: State) => state.totalResults;
-
+export const getresponsetime = (state: State) => state.responsetime;
 export const getNavigation = (state: State) => state.navigation;
 

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -14,6 +14,7 @@ import * as queryactions from '../actions/query';
 export class ResultsComponent implements OnInit {
   items$: Observable<any>;
   totalResults$: Observable<number>;
+  responseTime$: Observable<any>;
   resultDisplay: string;
   noOfPages: number;
   presentPage: number;
@@ -117,7 +118,6 @@ export class ResultsComponent implements OnInit {
               private store: Store<fromRoot.State>, private ref: ChangeDetectorRef, public themeService: ThemeService) {
 
     this.activatedroute.queryParams.subscribe(query => {
-      this.hidefooter = 1;
 
       if (query['fq']) {
 
@@ -161,12 +161,12 @@ export class ResultsComponent implements OnInit {
       this.presentPage = Math.abs(query['start'] / this.searchdata.rows) + 1;
 
     });
+    this.responseTime$ = store.select(fromRoot.getResponseTime);
+    this.responseTime$.subscribe(responsetime => {
+      this.hidefooter = 0;
+    });
     this.totalResults$ = store.select(fromRoot.getTotalResults);
     this.totalResults$.subscribe(totalResults => {
-      if (totalResults) {
-        this.hidefooter = 0;
-
-      }
 
       this.end = Math.min(totalResults, this.begin + this.searchdata.rows - 1);
       this.message = 'About ' + totalResults + ' results';
@@ -180,6 +180,7 @@ export class ResultsComponent implements OnInit {
     this.querychange$ = store.select(fromRoot.getquery);
     this.querychange$.subscribe(res => {
       this.searchdata.query = res;
+      this.hidefooter = 1;
     });
   };
 


### PR DESCRIPTION
Fixes issue #466 

Changes: 
1.using augury we could see that `this.hidefooter = 1` even though it is changed to `this.hidefooter = 0` when results are changed. but due to query parameters changing after results are changed and again as we have `this.hidefooter = 1` , whenever query parameters are changed this is leading to the error.
2.removed this.hidefooter = 1 when url activated route is changed and then made some changes such that extra errors doesn't get raised.

Demo Link:  https://susper-pr-474.herokuapp.com/

