### PR TITLE
Fixes #364: Suggestion box hides when query is erased

### DIFF
--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -35,16 +35,20 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
     this.query$ = store.select(fromRoot.getquery);
     this.query$.subscribe(query => {
       this.searchdata.query = query;
-
+      if (query === '') {
+        this.displayStatus = 'hidebox';
+      }
     });
 
   };
+
   hidebox(event: any) {
     if (event.which === 13) {
       this.displayStatus = 'hidebox';
       event.target.blur();
     }
   }
+
   hidesuggestions(data: number) {
     if (data === 1) {
       this.displayStatus = 'hidebox';
@@ -52,6 +56,7 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
       this.displayStatus = 'showbox';
     }
   }
+
   onquery(event: any) {
     this.store.dispatch(new query.QueryAction(event.target.value));
     if (event.target.value.length > 0) {


### PR DESCRIPTION
Fixes issue #364 

Changes: Suggestion box was not hiding when query was completely erased. Now, suggestion box will hide if query is empty or completely erased.

Demo Link: <a href="https://harshit98.github.io/susper.com/">here</a>

Screenshots for the change: 

![screenshot from 2017-06-13 22-22-56](https://user-images.githubusercontent.com/22245418/27094185-e4d97bd8-5086-11e7-93d6-9cb17ef72805.png)

Kindly review @nikhilrayaprolu @Marauderer97
