### PR TITLE
Fixes #485 results are removed when the query is quickly removed

### DIFF
--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -3,7 +3,7 @@
 <!-- Stop ignoring BootLintBear -->
   <div class="input-group" id="nav-group">
       <div class="input-text">
-      <input #input type="text" name="query" class="form-control" id="nav-input" (keyup)="onquery($event)"
+      <input #input type="text" name="query" class="form-control" id="nav-input" (ngModelChange)="onquery($event)"
            [(ngModel)]="searchdata.query" autocomplete="off">
       </div>
     <div class="input-group-btn">

--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -31,7 +31,7 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
   };
   querydata$: Observable<any>;
   constructor(private route: ActivatedRoute,
-    private router: Router, private store: Store<fromRoot.State>) {
+              private router: Router, private store: Store<fromRoot.State>) {
     this.query$ = store.select(fromRoot.getquery);
     this.query$.subscribe(query => {
       this.searchdata.query = query;
@@ -53,15 +53,12 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
     }
   }
   onquery(event: any) {
-    this.store.dispatch(new query.QueryAction(event.target.value));
-    if (event.target.value.length > 0) {
-      this.store.dispatch(new queryactions.QueryServerAction({'query': this.searchdata.query}));
-      this.displayStatus = 'showbox';
-      this.submit();
-      this.hidebox(event);
-    } else {
+    this.store.dispatch(new query.QueryAction(event));
+    this.store.dispatch(new queryactions.QueryServerAction({'query': event}));
+    this.displayStatus = 'showbox';
+    this.submit();
+    this.hidebox(event);
 
-    }
   }
   ShowAuto() {
     return (this.displayStatus === 'showbox');


### PR DESCRIPTION
Fixes issue #485 

Changes: replaced keyup with ngmodelchange such that it works for each query change

Demo Link: https://susper-pr-486.herokuapp.com/

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/15216503/27165913-cf3191ba-51b4-11e7-96e1-a2e3b01787bc.png)
