### PR TITLE
Fixes #487: Avoid failing of PRs if code coverage decreases

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -51,7 +51,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: null
+        threshold: 2%
         branches: null
 
     patch:
@@ -68,4 +68,4 @@ coverage:
 comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"
   branches: null
-behavior: default
+  behavior: default


### PR DESCRIPTION
Fixes issue #487 

Changes: Added a threshold value. It will allow the : 
- [x] coverage to drop by 2% and posting a success status. (coverage/project)
- [x] regarding failing of codecov/patch, it can't be fixed since it depends on the code covered in patch. It should be greater than or equal to coverage value (i.e 64.28% in Susper)

Demo Link: (Not appropriate here)

Kindly review @Marauderer97 @nikhilrayaprolu 
Let me know if any changes has to be done. :)