### PR TITLE
Fixes #495 about results message is shown

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -90,11 +90,11 @@ a {
   font-weight: 900;
   padding-bottom: 4%;
 }
-#progress-bar {
+.message-bar {
   margin-top: 1%;
   font-size: small;
   color: #808080;
-  margin-left: 11.2%;
+
 }
 
 .text-result {
@@ -328,9 +328,6 @@ a {
 }
 
 @media screen and (max-width:1139px) {
-  #progress-bar {
-    margin-left: 13%;
-  }
   #search-options {
     margin-left: 10.2%;
   }
@@ -342,9 +339,6 @@ a {
 @media screen and (max-width:1077px) {
   #search-options {
     margin-left: 9%;
-  }
-  #progress-bar {
-    margin-left: 12.1%;
   }
   .result {
     margin-left: 6.2%;
@@ -367,9 +361,6 @@ a {
   #search-options {
     margin-left: 8.8%;
   }
-  #progress-bar {
-    margin-left: 12.3%;
-  }
   .result {
     margin-left: 6.2%;
   }
@@ -385,9 +376,6 @@ a {
   #search-options {
     margin-left: 9.8%;
   }
-  #progress-bar {
-    margin-left: 14%;
-  }
   .result {
     margin-left: 7.7%;
   }
@@ -401,8 +389,7 @@ a {
     margin-left: 16%;
     padding-right: 30px;
   }
-  #progress-bar {
-    margin-left: 13.4%;
+  .message-bar {
     margin-bottom: -10px;
   }
   #search-options {
@@ -439,9 +426,7 @@ a {
   .result {
     margin-left: 13%;
   }
-  #progress-bar {
-    margin-left: 12.3%;
-  }
+
 }
 
 @media screen and (max-width:639px) {
@@ -455,9 +440,7 @@ a {
     margin-left: 12%;
     padding-right: 20px;
   }
-  #progress-bar {
-    margin-left: 11%;
-  }
+
   #pag-bar {
     padding-left: 30px;
   }

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -23,10 +23,11 @@
   <div *ngIf="!hidefooter">
     <!-- Basic results 'All' -->
   <div class="text-result" *ngIf="Display('all')">
-      <div class="container-fluid" id="progress-bar">
-          {{message}}
-      </div>
+
     <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+      <div class="result message-bar">
+        {{message}}
+      </div>
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
                     <a class="title-pointer" href="{{item.link}}" [style.color]="themeService.titleColor">{{item.title}}</a>
@@ -54,7 +55,7 @@
     </div>
     <!-- END -->
         <div class="video-result" *ngIf="Display('videos')">
-            <div class="container-fluid" id="progress-bar">
+            <div class="result message-bar">
                 {{message}}
             </div>
             <div *ngFor="let item of items$|async" class="result">

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -151,7 +151,6 @@ export class ResultsComponent implements OnInit {
       this.querylook = Object.assign({}, query);
       this.searchdata.sort = query['sort'];
       this.begin = Number(query['start']) + 1;
-      this.message = '';
       this.start = (this.presentPage - 1) * this.searchdata.rows;
       this.begin = this.start + 1;
 


### PR DESCRIPTION
Fixes issue #495 

Changes: since our url changes after results are shown, removed `message=''` from `activatedroute.subscribe`

Demo Link:https://susper-pr-496.herokuapp.com/

Screenshots for the change: 


![image](https://user-images.githubusercontent.com/15216503/27235657-427648de-52df-11e7-9d79-eb60882b9efd.png)
