### PR TITLE
Fixes #498, displays appropriate message when no results are displayed

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -291,6 +291,27 @@ a {
   clear: both;
 }
 
+.noResults{
+  margin-left: 3%;
+  margin-top: 7%;
+  font-size: medium;
+  font-weight: normal;
+}
+.noResults >p{
+  margin-top: 10px;
+  margin-bottom: 15px;
+}
+.noResults >ul{
+  padding-left: 16px;
+}
+.noResults >ul> li {
+  padding-top: 0;
+  padding-bottom: 18px;
+}
+.noResults em{
+  font-weight: bold;
+  font-style: normal;
+}
 @media screen and (min-width:1920px) {
   #tools {
     margin-left: 27%;
@@ -489,3 +510,4 @@ a {
     padding: 0px 5.6% 12px;
   }
 }
+

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -23,9 +23,20 @@
   <div *ngIf="!hidefooter">
     <!-- Basic results 'All' -->
   <div class="text-result" *ngIf="Display('all')">
-      <div class="container-fluid" id="progress-bar">
+      <div class="container-fluid" *ngIf="totalNumber > 0" id="progress-bar">
           {{message}}
       </div>
+    <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+      <div class="noResults">
+      <p>Your search - <em>{{searchdata.query}}</em> - did not match any documents.</p>
+      <p>Suggestions:</p>
+      <ul>
+        <li>Make sure that all words are spelled correctly.</li>
+        <li>Try different keywords.</li>
+        <li>Try more general keywords.</li>
+      </ul>
+      </div>
+    </div>
     <div class="feed col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
@@ -47,6 +58,17 @@
     <!-- Image section -->
     <div class="container">
         <div class="grid" *ngIf="Display('images')">
+          <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+            <div class="noResults">
+              <p>Your search - <em>{{searchdata.query}}</em> - did not match any images.</p>
+              <p>Suggestions:</p>
+              <ul>
+                <li>Make sure that all words are spelled correctly.</li>
+                <li>Try different keywords.</li>
+                <li>Try more general keywords.</li>
+              </ul>
+            </div>
+          </div>
             <div class="cell" *ngFor="let item of items$|async">
                 <a class="image-pointer" href="{{item.link}}"><img class="responsive-image" src="{{item.link}}"></a>
             </div>
@@ -54,9 +76,20 @@
     </div>
     <!-- END -->
         <div class="video-result" *ngIf="Display('videos')">
-            <div class="container-fluid" id="progress-bar">
-                {{message}}
+          <div class="container-fluid" *ngIf="totalNumber > 0" id="progress-bar">
+            {{message}}
+          </div>
+          <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+            <div class="noResults">
+              <p>Your search - <em>{{searchdata.query}}</em> - did not match any videos.</p>
+              <p>Suggestions:</p>
+              <ul>
+                <li>Make sure that all words are spelled correctly.</li>
+                <li>Try different keywords.</li>
+                <li>Try more general keywords.</li>
+              </ul>
             </div>
+          </div>
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">
                     <a class="title-pointer" href="{{item.path}}">{{item.title}}</a>

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -38,6 +38,7 @@ export class ResultsComponent implements OnInit {
   };
   querylook = {};
   hidefooter = 1;
+  totalNumber: number;
   querychange$: Observable<any>;
   resultscomponentchange$: Observable<any>;
   getNumber(N) {
@@ -169,7 +170,8 @@ export class ResultsComponent implements OnInit {
     this.totalResults$.subscribe(totalResults => {
 
       this.end = Math.min(totalResults, this.begin + this.searchdata.rows - 1);
-      this.message = 'About ' + totalResults + ' results';
+      this.totalNumber = totalResults;
+        this.message = 'About ' + totalResults + ' results';
       this.noOfPages = Math.ceil(totalResults / this.searchdata.rows);
       this.maxPage = Math.min(this.searchdata.rows, this.noOfPages);
     });


### PR DESCRIPTION
Fixes issue #498 
Changes: displays appropriate message when no results are displayed for images, videos and text

Demo Link: https://marauderer97.github.io/susper.com/

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/27252909-f0ef1632-5386-11e7-95f6-049db159e874.png)
![image](https://user-images.githubusercontent.com/20185076/27252912-fc2cd34a-5386-11e7-931f-0b936c916026.png)
![image](https://user-images.githubusercontent.com/20185076/27252917-0bbefcfc-5387-11e7-9a22-23562aec5f26.png)
