### PR TITLE
Fixes #514, Tools drop-down made to resemble drop-down in Google

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -267,9 +267,10 @@ a {
 
 #tool-dropdown li {
   text-align: left;
+  color: #000000;
   display: block;
-  padding-top: 16px;
-  padding-bottom: 24px;
+  padding-top: 8px;
+  padding-bottom: 22px;
 }
 
 #setting-dropdown li {
@@ -285,6 +286,13 @@ a {
   margin-left: 15%;
   border-radius: 0px;
 }
+
+#tool-dropdown{
+  margin-top: 8%;
+  margin-left: 15%;
+  border-radius: 0px;
+}
+
 #pag-bar {
   padding-left: 60px;
   padding-top: 20px;


### PR DESCRIPTION
Fixes issue #514 

Changes: Tools drop-down made to resemble drop-down in Google, in terms of
- Border radius
- Background color
- Font color
- top and bottom paddings being decreased
- the margin on the left being increased

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
Before
![image](https://user-images.githubusercontent.com/20185076/27290569-41b2a98a-552b-11e7-8e6a-1e24d610371a.png)

Now
![image](https://user-images.githubusercontent.com/20185076/27290525-21e59db0-552b-11e7-99a9-1ccf1c16c057.png)

