### PR TITLE
Fixes #521, design bugs in crawl page removed

### DIFF
--- a/src/app/crawlstart/crawlstart.component.html
+++ b/src/app/crawlstart/crawlstart.component.html
@@ -133,14 +133,13 @@
         </div>
       </div>
       <div class="form-group">
-        <div class="col-md-4"><label for="safe search">Must-Match List for Country Codes
-          info </label>
+        <div class="col-md-4">Must-Match List for Country Codes
         </div>
         <div class="col-md-6">
-          <input name="country" [(ngModel)]="crawlvalues.countryMustMatchSwitch" type="radio" id="safe search">
+          <input name="countryMustMatchSwitch" type="radio" [(ngModel)]="crawlvalues.countryMustMatchSwitch" value="0" [checked]="crawlvalues.countryMustMatchSwitch==='0'">
           no country code restriction
-          <input name="country" [(ngModel)]="crawlvalues.countryMustMatchSwitch" type="radio">Use filter
-          <input name="country" [(ngModel)]="crawlvalues.countryMustMatchList" class="form-control" type="text" size="60" maxlength="256">
+          <input name="countryMustMatchSwitch" [(ngModel)]="crawlvalues.countryMustMatchSwitch" id="countryMustMatchSwitch" value="1" type="radio" >Use filter
+          <input name="countryMustMatchList" [(ngModel)]="crawlvalues.countryMustMatchList" id="countryMustMatchList" type="text" size="60" maxlength="256">
         </div>
       </div>
     </div>
@@ -252,9 +251,7 @@
       <div class="form-group">
         <div class="col-md-4"><label>Multiple Snapshot Versions</label></div>
         <div class="col-md-6"><input name="replaceold" [(ngModel)]="crawlvalues.snapshotsReplaceOld" value="on" type="radio">replace old snapshots with new ones
-        <div class="col-md-6"><input name="replaceold" [(ngModel)]="crawlvalues.snapshotsReplaceOld" value="on" type="radio">replace old snapshots with new ones
           <input name="replaceold" type="radio" value="off" [(ngModel)]="crawlvalues.snapshotsReplaceOld">add new versions for each crawl
-        </div>
       </div>
       <div class="form-group">
         <div class="col-md-4">

--- a/src/app/crawlstart/crawlstart.component.ts
+++ b/src/app/crawlstart/crawlstart.component.ts
@@ -34,6 +34,8 @@ export class CrawlstartComponent implements OnInit {
     "storeHTCache": "off",
     "cachePolicy": "if fresh",
     "indexText": "on",
+    "countryMustMatchSwitch": "0",
+    "countryMustMatchList": "AD,AL,AT,BA,BE,BG,BY,CH,CY,CZ,DE,DK,EE,ES,FI,FO,FR,GG,GI,GR,HR,HU,IE,IM,IS,IT,JE,LI,LT,LU,LV,MC,MD,MK,MT,NL,NO,PL,PT,RO,RU,SE,SI,SJ,SK,SM,TR,UA,UK,VA,YU",
     "indexMedia": "off",
     "collection": "user",
     "agentName": ""


### PR DESCRIPTION
Fixes issue #521 
Changes: Fixed design bugs in crawl page
-  User can now select no country code restriction radio button, similar to yacy
- Added values to radio buttons, with a default, checked radio button
-  Input box corresponding to country codes now has values, similar to yacy
- Removed duplicate radio buttons

Demo Link:[Here]( https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/20185076/27293617-960c8696-5534-11e7-9fcc-17d785912d81.png)
![image](https://user-images.githubusercontent.com/20185076/27293636-a38ed828-5534-11e7-9d74-5ad05654d682.png)

@nikhilrayaprolu @harshit98 Kindly review