### PR TITLE
Fixes #516, footer navbar enhanced and decluttered

### DIFF
--- a/src/app/footer-navbar/footer-navbar.component.css
+++ b/src/app/footer-navbar/footer-navbar.component.css
@@ -38,6 +38,28 @@ div a {
   cursor: pointer;
 }
 
-.dropdown-menu > li > a{
-  text-align: center;
+#fsett {
+  background: #fff;
+  border: 1px solid #999;
+  bottom: 30px;
+  padding: 10px 0;
+  position: absolute;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  text-align: left;
+  z-index: 104;
+  margin-left: -85%;
+  margin-bottom: -9%;
+}
+
+#fsett a {
+  display: block;
+  line-height: 44px;
+  padding: 0 20px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+#fsett a:hover {
+  text-decoration: underline;
+  background-color: white;
 }

--- a/src/app/footer-navbar/footer-navbar.component.html
+++ b/src/app/footer-navbar/footer-navbar.component.html
@@ -6,19 +6,16 @@
             <a href="//github.com/fossasia/susper.com" id="code">Code</a>
         </div>
         <div class="right-side">
-          <a routerLink="/terms" routerLinkActive="active">Terms</a>
-          <a routerLink="/contact" routerLinkActive="active">Contact</a>
           <span class="dropup">
             <a class="dropdown-toggle" data-toggle="dropdown">Settings</a>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu" id="fsett">
               <li><a routerLink="/preferences">Search settings</a></li>
+              <li><a routerLink="/advancedsearch">Advanced Search</a></li>
+              <li><a routerLink="/crawlstartexpert" routerLinkActive="active">Crawl Job</a></li>
             </ul>
           </span>
-            <a routerLink="/advancedsearch" routerLinkActive="active">Advanced Search</a>
-            <a routerLink="/terms" routerLinkActive="active">Terms</a>
-            <a routerLink="/contact" routerLinkActive="active">Contact</a>
-          <a routerLink="/crawlstartexpert" routerLinkActive="active">Crawl Job</a>
-          <a routerLink="/preferences" routerLinkActive="active">Settings</a>
+          <a routerLink="/terms" routerLinkActive="active">Terms</a>
+          <a routerLink="/contact" routerLinkActive="active">Contact</a>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Fixes issue #516 

Changes: Enhance footer navbar in the following ways
- Removes extra links
- Adds advanced search, crawl job and search settings under settings
- Changes drop up to match Google exactly by 
1. Removing background colour on hover
2. Adding underline on hover
3. Repositioning drop up to centre
4. Changing border thickness, padding, margins etc.


Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

This is how Google drop up looks
![image](https://user-images.githubusercontent.com/20185076/27337255-76ac3290-55ef-11e7-9750-5e4a8865112a.png)

New susper drop up
![image](https://user-images.githubusercontent.com/20185076/27337282-8ff6ed6c-55ef-11e7-9778-6fe960fdb269.png)

Old susper navbar and drop up
![image](https://user-images.githubusercontent.com/20185076/27337301-a3aa5006-55ef-11e7-8521-2c80a8e91a1c.png)
