### PR TITLE
Fixes #515, footer sticks to bottom of the page

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -138,4 +138,5 @@
 
 <!--footer navigation bar goes here-->
 </div>
+</div>
 <app-footer-navbar [hidden]="hidefooter"></app-footer-navbar>


### PR DESCRIPTION
Fixes issue #515 

Changes: Footer always sticks to the bottom of the page, even if content is less

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/20185076/27339783-5a3b0bd4-55f6-11e7-9e94-3169fddbd48a.png)
