### PR TITLE
Fixes #533, sets page number to zero on new query

### DIFF
--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -61,12 +61,12 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
     let instantsearch = JSON.parse(localStorage.getItem('instantsearch'));
 
     if (instantsearch && instantsearch.value) {
-      this.store.dispatch(new queryactions.QueryServerAction({'query': event, start: this.searchdata.start, rows: this.searchdata.rows}));
+      this.store.dispatch(new queryactions.QueryServerAction({'query': event, start: 0, rows: this.searchdata.rows}));
       this.displayStatus = 'showbox';
       this.hidebox(event);
     } else {
       if (event.which === 13) {
-        this.store.dispatch(new queryactions.QueryServerAction({'query': event, start: this.searchdata.start, rows: this.searchdata.rows}));
+        this.store.dispatch(new queryactions.QueryServerAction({'query': event, start: 0, rows: this.searchdata.rows}));
         this.displayStatus = 'showbox';
         this.hidebox(event);
       }


### PR DESCRIPTION
Fixes issue #533 

Changes: Sets page number back to zero, whenever a new query is fired

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
(Not applicable here)

@nikhilrayaprolu Please check if this change was suitable, I have crosschecked with links from different sources(infobox, related searches etc, and they are working, since a new query needs to be displayed from page 1 I did this, please review. If we use this.searchdata.start, the value from the previous query gets carried