### PR TITLE
Fixes #532, no extra pages shown at end of pagination bar

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -116,10 +116,9 @@
                 <ul class="pagination" id="pag-bar">
                   <li class="page-item2" *ngIf="!getStyle(1)"><span class="spl" (click)="decPresentPage()"><div class="arrow">< </div><div class="side-text">Previous</div></span></li>
                   <li class="page-item"><span class="page-link" href="#" (click)="decPresentPage()"><div class="page-text prev">S</div><br/></span></li>
-                    <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link" *ngIf="presentPage>=4 && num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
+                    <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link" *ngIf="presentPage>=4 && presentPage-3+num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
                                                                                        (click)="getPresentPage(presentPage-3+num)" href="#"><div [class.active_page]="getStyle(presentPage-3+num)" class="page-text">U</div><span class="page-number">{{presentPage-3+num}}</span></span>
                         <span class="page-link" *ngIf="presentPage<4 && num<=noOfPages" [class.active_page]="num+1 == presentPage" (click)="getPresentPage(num+1)"
-
                               href="#"><div [class.active_page]="num+1 == presentPage" class="page-text">U</div><span class="page-number">{{num+1}}</span></span></li>
                       <li class="page-item"><span class="page-link" (click)="incPresentPage()"><div class="page-text next">SPER</div></span></li>
                   <li class="page-item2" *ngIf="!getStyle(maxPage)"><span class="spl" (click)="incPresentPage()"><div class="arrow">></div><div class="side-text">Next</div></span></li>


### PR DESCRIPTION
Fixes issue #532 

Changes: Removes extra 3 pages at the end of pagination bar

Demo Link:[Here]( https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
Before:
![image](https://user-images.githubusercontent.com/20185076/27396080-9fa3bc28-56cf-11e7-99d5-c1429e97a3c9.png)

After:
![image](https://user-images.githubusercontent.com/20185076/27396067-9293791a-56cf-11e7-91af-d70a9d6068d2.png)
