### PR TITLE
Fixes 539 Dbpedia results are displayed now

### DIFF
--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -24,23 +24,18 @@ export class InfoboxComponent implements OnInit {
     this.query$.subscribe(query => {
       this.keyword = query;
     });
-    this.resultscomponentchange$ = store.select(fromRoot.getItems);
-    this.resultscomponentchange$.subscribe(res => {
-      this.results = this.initialresults;
-    });
     this.response$ = store.select(fromRoot.getKnowledge);
-    this.initialresults = [];
     this.response$.subscribe(res => {
       if (res.results) {
         if (res.results[0]) {
           if (res.results[0].label.toLowerCase().includes(this.keyword.toLowerCase())) {
-            this.initialresults = res.results;
+            this.results = res.results;
           } else {
-              this.initialresults = [];
+              this.results = [];
             }
         }
       } else {
-          this.initialresults = [];
+          this.results = [];
         }
 
     });


### PR DESCRIPTION
Fixes issue #539 
Now Dbpedia results are shown whatever be the situation.
whenever results are changed before the infobox service results are out, there are no `this.results=this.initialresults` being called due to which the results are not being shown.


Demo Link: https://susper-pr-541.herokuapp.com/

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/15216503/27446884-a25202ae-579c-11e7-92c1-9f8b5056e64e.png)

[Add here the screenshot of the fix]