### PR TITLE
Fixes #542 related searches being shown in all times

### DIFF
--- a/src/app/related-search/related-search.component.ts
+++ b/src/app/related-search/related-search.component.ts
@@ -26,15 +26,11 @@ export class RelatedSearchComponent implements OnInit {
       this.keyword = query;
     });
     this.results = [];
-    this.resultscomponentchange$ = store.select(fromRoot.getItems);
-    this.resultscomponentchange$.subscribe(res => {
-      this.results = this.initialresults;
-    });
 
 
     this.response$ = store.select(fromRoot.getKnowledge);
     this.response$.subscribe(res => {
-      this.initialresults = res.results || [];
+      this.results = res.results || [];
 
     });
   }


### PR DESCRIPTION
Fixes issue #542 
Now related search is being shown in all situations.

Demo Link: https://susper-pr-543.herokuapp.com/

Screenshots for the change: 
Before:-
![image](https://user-images.githubusercontent.com/15216503/27447546-f150a46c-579e-11e7-8d22-31c5a1ef5b4a.png)
after:-
![image](https://user-images.githubusercontent.com/15216503/27447556-fec5afb6-579e-11e7-9177-83b0d9171a3e.png)
