### PR TITLE
Fixes #528 now 'never show instant results' works in all situations

### DIFF
--- a/src/app/searchsettings/searchsettings.component.ts
+++ b/src/app/searchsettings/searchsettings.component.ts
@@ -24,7 +24,7 @@ export class SearchsettingsComponent implements OnInit {
     if (this.instantresults) {
       localStorage.setItem('instantsearch', JSON.stringify({value: true}));
     } else {
-      localStorage.setItem('instantsearch', JSON.stringify({ value: false }));
+      localStorage.removeItem('instantsearch');
       localStorage.setItem('resultscount', JSON.stringify({ value: this.resultCount }));
     }
     this.router.navigate(['/']);


### PR DESCRIPTION
Fixes issue #528 clicking on "never show instant results" works on all cases.
Changes: deleted the localStorage instant search object when there is an option selection of "never show instant results". thereby it works in all situations

Demo Link: https://susper-pr-544.herokuapp.com/
