### PR TITLE
Fixes #490 Related searches size changed and aligned

### DIFF
--- a/src/app/infobox/infobox.component.css
+++ b/src/app/infobox/infobox.component.css
@@ -35,7 +35,9 @@ h3 {
 a {
   color: #1a0dab;
   text-decoration: none;
-  margin-left: -11px;
+  margin-left: -14px;
+  font-size: 13px;
+  font-family: Arial, sans-serif;
 }
 
 /** Screen Responsiveness **/

--- a/src/app/related-search/related-search.component.css
+++ b/src/app/related-search/related-search.component.css
@@ -3,11 +3,23 @@
   padding-top: 10px;
   max-width: 450px;
 }
-.h3{
-  padding-bottom: 1%;
+
+.container {
+  margin-right: 0px;
+  margin-left: -7px;
+  padding-left: 0px;
+  padding-right: 0px;
 }
+
+.heading {
+  padding-bottom: 8px;
+  color: #222;
+  font-size: 18px;
+  font-family: Arial, sans-serif;
+}
+
 .related{
-  padding: 3px 32px 3px 0;
+  margin-top: 10px;
   display: inline-block;
   width: 180px;
   float: left;
@@ -17,8 +29,9 @@
   color: #1a0dab;
   text-decoration: none;
   font-family: Arial, sans-serif;
-  font-size: 13px;
+  font-size: 14px;
 }
+
 .rellink:hover{
   text-decoration: underline;
 }

--- a/src/app/related-search/related-search.component.html
+++ b/src/app/related-search/related-search.component.html
@@ -1,7 +1,8 @@
-<div *ngIf="results?.length > 0" class="card">
-    <h3>Searches related to {{this.keyword}}</h3>
+<div class="container">
+  <div *ngIf="results?.length > 0" class="card">
+    <h3 class="heading">Searches related to {{this.keyword}}</h3>
     <div *ngFor="let result of results" class="related">
       <a [routerLink]="resultsearch" [queryParams]="{query: result.label}" class="rellink">{{result.label}}</a>
     </div>
   </div>
-
+</div>

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -303,9 +303,10 @@ a {
 }
 
 #pag-bar {
-  padding-left: 60px;
   padding-top: 20px;
   width: 100%;
+  margin-top: -24px;
+  margin-left: 200px;
 }
 
 .pagination-property {
@@ -336,21 +337,26 @@ a {
   font-size: medium;
   font-weight: normal;
 }
+
 .noResults >p{
   margin-top: 10px;
   margin-bottom: 15px;
 }
+
 .noResults >ul{
   padding-left: 16px;
 }
+
 .noResults >ul> li {
   padding-top: 0;
   padding-bottom: 18px;
 }
+
 .noResults em{
   font-weight: bold;
   font-style: normal;
 }
+
 @media screen and (min-width:1920px) {
   #tools {
     margin-left: 27%;
@@ -398,7 +404,6 @@ a {
     margin-left: 6.2%;
   }
 }
-
 
 @media screen and (max-width:979px) {
   #search-options {
@@ -463,7 +468,6 @@ a {
   .result {
     margin-left: 13%;
   }
-
 }
 
 @media screen and (max-width:639px) {
@@ -477,7 +481,6 @@ a {
     margin-left: 12%;
     padding-right: 20px;
   }
-
   #pag-bar {
     padding-left: 30px;
   }
@@ -503,4 +506,3 @@ a {
     padding: 0px 5.6% 12px;
   }
 }
-


### PR DESCRIPTION
Fixes issue #490 

Changes: 
- Enlarged the text size of related searches.
- Aligned the related searches properly.

Demo Link: http://harshit98.github.io/susper.com

Screenshots for the change: 

![screenshot from 2017-06-23 10-25-17](https://user-images.githubusercontent.com/22245418/27467244-773e1c62-57fe-11e7-85f7-3317bb8d7a0d.png)

![screenshot from 2017-06-23 10-25-26](https://user-images.githubusercontent.com/22245418/27467248-7ad3aa72-57fe-11e7-818e-aa134988b1b9.png)

![screenshot from 2017-06-23 10-27-18](https://user-images.githubusercontent.com/22245418/27467262-91622516-57fe-11e7-8386-cb61a3b83215.png)

Kindly review @nikhilrayaprolu @Marauderer97 
