### PR TITLE
Fixes #550, Images and vidoes are working now

### DIFF
--- a/src/app/dropdown/dropdown.component.css
+++ b/src/app/dropdown/dropdown.component.css
@@ -1,6 +1,6 @@
 li.dropdown-menu-box {
     left: 450px;
-    top: -50px;
+    top: 10px;
 }
 
 .dropdown-menu {
@@ -69,6 +69,10 @@ p.bug {
     margin-left: 7px;
 }
 
+#side-menu{
+  width:0;
+  float: right;
+}
 
 div#text-bug {
     margin-left: -5px;

--- a/src/app/index/index.component.css
+++ b/src/app/index/index.component.css
@@ -21,7 +21,7 @@
 
 .dropdown-menu-box-homepage {
   padding-right: 500px;
-  margin-top: -16%;
+  margin-top: -20%;
 }
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
Fixes issue #550 
Changes: Images and Video tabs working now, due to the recent addition of a dropdown, it was blocking the tabs. Reduced the size of the drop-down, and floated it to the right.

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/27494396-5109cc36-586b-11e7-8d83-e0cd625efec9.png)
@harshit98 @nikhilrayaprolu Please review.
