### PR TITLE
Fixed #552, added a tip to top of drop down

### DIFF
--- a/src/app/dropdown/dropdown.component.css
+++ b/src/app/dropdown/dropdown.component.css
@@ -2,13 +2,34 @@ li.dropdown-menu-box {
     left: 450px;
     top: 10px;
 }
-
-.dropdown-menu {
-    height: 500px;
-    width: 327px;
-    padding: 28px;
+.dropdown-menu{
+  height: 500px;
+  width: 327px;
+  padding: 28px;
 }
 
+.dropdown-menu:before {
+  position: absolute;
+  top: -7px;
+  right: 19px;
+  display: inline-block;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #ccc;
+  border-left: 7px solid transparent;
+  border-bottom-color: rgba(0, 0, 0, 0.2);
+  content: '';
+}
+
+.dropdown-menu:after {
+  position: absolute;
+  top: -5px;
+  right: 20px;
+  display: inline-block;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid #ffffff;
+  border-left: 6px solid transparent;
+  content: '';
+}
 div.block:hover {
     border: 1px solid rgba(150,150,150,0.3);
 }


### PR DESCRIPTION
Fixes issue #552 

Changes: Changes drop-down, to add a tip at the top just like Google

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
Before:
![image](https://user-images.githubusercontent.com/20185076/27508665-9adbe370-5907-11e7-9f5a-7e6e3de5eec3.png)


After:
![image](https://user-images.githubusercontent.com/20185076/27508662-92934366-5907-11e7-88ef-23ed717a22a7.png)

