### PR TITLE
Addresses #3, Adding basic tests for results component

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -110,6 +110,7 @@
 
         <br>
         <div class="clean"></div>
+    <div class="pagination-bar">
         <div class="pagination-property" *ngIf="noOfPages>1">
             <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
                 <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
@@ -127,6 +128,7 @@
                 </div>
             </nav>
         </div>
+    </div>
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <app-advancedsearch></app-advancedsearch>
 </div>

--- a/src/app/results/results.component.spec.ts
+++ b/src/app/results/results.component.spec.ts
@@ -93,4 +93,77 @@ describe('ResultsComponent', () => {
     expect(compiled.querySelector('app-advancedsearch')).toBeTruthy();
   });
 
+  it('should have an app-related-search element', () => {
+    let compiled = fixture.debugElement.nativeElement;
+
+    expect(compiled.querySelector('app-related-search')).toBeTruthy();
+  });
+
+  it('should have an footer-navbar element', () => {
+    let compiled = fixture.debugElement.nativeElement;
+
+    expect(compiled.querySelector('app-footer-navbar')).toBeTruthy();
+  });
+
+  it('should have an app-infobox element', () => {
+    let compiled = fixture.debugElement.nativeElement;
+
+    expect(compiled.querySelector('app-infobox')).toBeTruthy();
+  });
+
+  it('should have an app-theme element', () => {
+    let compiled = fixture.debugElement.nativeElement;
+
+    expect(compiled.querySelector('app-theme')).toBeTruthy();
+  });
+
+
+  it('should have a search options menu', () => {
+    let compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('div#search-options-field ul#search-options'));
+  });
+
+  it('should have "items$" variable', () => {
+    expect(component.items$).toBeTruthy();
+  });
+
+  it('should have a tool drop-down menu', () => {
+    let compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('ul#tool-dropdown'));
+  });
+
+  it('should have a tool drop-down menu', () => {
+    let compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('ul#setting-dropdown'));
+  });
+
+  it('should have a pagination bar', () => {
+    let compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('div.pagination-bar'));
+  });
+
+  it('should have correctly related sub-components', () => {
+    let compiled = fixture.debugElement.nativeElement;
+    if (component.resultDisplay.toLocaleLowerCase() === 'all') {
+      expect(compiled.querySelector('div.text-result div.title'));
+      expect(compiled.querySelector('div.text-result div.link'));
+      expect(compiled.querySelector('div.text-result div.description'));
+    } else if (component.resultDisplay.toLocaleLowerCase() === 'images') {
+      expect(compiled.querySelector('div.grid div.cell'));
+      expect(compiled.querySelector('div.grid div.cell a.image-pointer'));
+    } else if (component.resultDisplay.toLocaleLowerCase() === 'videos') {
+      expect(compiled.querySelector('div.video-result div.title'));
+      expect(compiled.querySelector('div.video-result div.link'));
+    }
+  });
+
+  it('should have appropriate message', () => {
+    let compiled = fixture.debugElement.nativeElement;
+    if (component.totalNumber < 1) {
+      expect(compiled.querySelector('div.noResults'));
+    } else if  (component.totalNumber > 0) {
+      expect(compiled.querySelector('div.message-bar'));
+    }
+  });
+
 });


### PR DESCRIPTION
Related to issue #3 

Changes: Adds basic tests for results component

Demo Link:
[Here](https://marauderer97.github.io/susper.com/)
Screenshots for the change: 

(Not applicable)

@nikhilrayaprolu @harshit98 Please check, I have also updated the sheet posted by @nikhilrayaprolu in Gitter(as many columns as I understood what to fill)