### PR TITLE
Fixes #562, changes link-styling on hover and active similar to market leader

### DIFF
--- a/src/app/footer-navbar/footer-navbar.component.css
+++ b/src/app/footer-navbar/footer-navbar.component.css
@@ -18,6 +18,14 @@ div a {
   text-decoration: none;
 }
 
+div a:hover{
+  text-decoration: underline;
+}
+
+div a:active{
+  color: blue;
+}
+
 @media(max-width: 750px) {
   footer{
     justify-content: center;


### PR DESCRIPTION

Fixes issue #562 

Changes: 
Bottom bar link design on hover and active. Note: I have made the links blue on active instead of red like the market leader because the main theme of Susper is blue.

Demo Link:[Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/20185076/27600535-e358c9fe-5b89-11e7-8ede-b0369b5c104d.png)
@nikhilrayaprolu @harshit98 Kindly review