### PR TITLE
Fixes #383, Results are displayed in the same tab as before

### DIFF
--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -22,7 +22,8 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
   searchdata = {
     query: '',
     rows: 10,
-    start: 0
+    start: 0,
+    fq: ''
   };
   wholequery$: Observable<any>;
   resultspage: any;
@@ -54,7 +55,15 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
 
   onEnter(event: any) {
     if (event.which === 13) {
-      this.store.dispatch(new queryactions.QueryServerAction({'query': event.target.value, start: 0, rows: this.searchdata.rows}));
+      if (this.searchdata.fq !== '') {
+        this.store.dispatch(new queryactions.QueryServerAction({'query': event.target.value, start: 0, rows: this.searchdata.rows, fq: this.searchdata.fq}));
+      } else {
+        this.store.dispatch(new queryactions.QueryServerAction({
+          'query': event.target.value,
+          start: 0,
+          rows: this.searchdata.rows
+        }));
+      }
       this.displayStatus = 'hidebox';
       event.target.blur();
       event.preventDefault();
@@ -67,8 +76,15 @@ export class SearchBarComponent implements OnInit, AfterViewInit {
     let instantsearch = JSON.parse(localStorage.getItem('instantsearch'));
 
     if (instantsearch && instantsearch.value) {
-      this.store.dispatch(new queryactions.QueryServerAction({'query': event, start: 0, rows: this.searchdata.rows}));
-      this.displayStatus = 'showbox';
+      if (this.searchdata.fq !== '') {
+        this.store.dispatch(new queryactions.QueryServerAction({'query': event, start: 0, rows: this.searchdata.rows, fq: this.searchdata.fq}));
+      } else {
+        this.store.dispatch(new queryactions.QueryServerAction({
+          'query': event,
+          start: 0,
+          rows: this.searchdata.rows
+        }));
+      }      this.displayStatus = 'showbox';
     }
   }
 


### PR DESCRIPTION
Fixes issue #383
Changes: When a new query was typed previously, the tab would change to the default 'all' tab, now it stays on the same tab

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
Not Applicable