### PR TITLE
Fixes #600, Repositions text and images to center highlight boxes for dropdowns

### DIFF
--- a/src/app/dropdown/dropdown.component.css
+++ b/src/app/dropdown/dropdown.component.css
@@ -33,6 +33,9 @@ li.dropdown-menu-box {
 div.block:hover {
     border: 1px solid rgba(150,150,150,0.3);
 }
+div.block{
+  text-align: center;
+}
 
 p {
     padding: 10px;
@@ -44,7 +47,15 @@ p {
 }
 
 div#loklak-logo {
-    padding-left: 16px;
+    padding-top: 6px;
+}
+
+div#fossasia-logo {
+  padding-top: 6px;
+}
+
+div#susi-logo {
+  padding-top: 6px;
 }
 
 img.eventyay {

--- a/src/app/dropdown/dropdown.component.html
+++ b/src/app/dropdown/dropdown.component.html
@@ -69,9 +69,9 @@
         <!--Third row starts from here-->
         <div class="row">
           <div class="col-sm-4">
-            <div class="block">
+            <div class="block" id="fossasia-logo">
               <a href="//fossasia.org" target="_blank">
-                  <img src="../../assets/images/fossasia.png" style="width: 68px; height: 46px">
+                  <img src="../../assets/images/fossasia.png" style="width: 68px; height: 46px" class="fossasia">
                   <p class="fossasia-text">FOSSASIA</p>
                 </a>
             </div>
@@ -85,7 +85,7 @@
             </div>
           </div>
           <div class="col-sm-4">
-            <div class="block">
+            <div class="block" id="susi-logo">
               <a href="//chat.susi.ai" target="_blank">
                 <img src="../../assets/images/susi.jpg" class="susi">
                 <p>SUSI</p>


### PR DESCRIPTION

Fixes issue #600 

Changes: Repositions text and images to center highlight boxes for dropdowns

Demo Link:[Here]( https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/27914544-258f5312-6281-11e7-9c6e-f0872bf0ecb9.png)
