### PR TITLE
Fixes #610, auto-correct not displayed when wrong query is removed

### DIFF
--- a/src/app/auto-correct/auto-correct.component.ts
+++ b/src/app/auto-correct/auto-correct.component.ts
@@ -24,11 +24,14 @@ export class AutoCorrectComponent implements OnInit {
       if (query) {
             this.sugflag = false;
             this.autocorrectservice.getsearchresults(query).subscribe(res => {
+              this.sugflag = false;
                 if (res) {
                     if (res['original'].toLocaleLowerCase() !== res['suggestion'].toLocaleLowerCase()) {
                         this.sugflag = true;
                         this.suggestion = res['suggestion'];
-                      }
+                      } else {
+                      this.sugflag = false;
+                    }
                     }
               });
           }


### PR DESCRIPTION
Fixes issue: #610,

Changes:  auto-correct not displayed when the wrong query is removed, it is displayed only if the spelling is wrong

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

Screenshots are not applicable