### PR TITLE
Fixes #617, question mark in the query is not shown as incorrect

### DIFF
--- a/src/app/auto-correct/auto-correct.component.ts
+++ b/src/app/auto-correct/auto-correct.component.ts
@@ -15,6 +15,7 @@ export class AutoCorrectComponent implements OnInit {
   suggestion: any;
   sugflag: boolean;
   resultsearch = '/search';
+  isQues: boolean;
   @Output() hidecomponent: EventEmitter<any> = new EventEmitter<any>();
   constructor(private autocorrectservice: AutocorrectService, private route: Router, private activatedroute: ActivatedRoute,
               private store: Store<fromRoot.State>, private ref: ChangeDetectorRef) {
@@ -23,11 +24,13 @@ export class AutoCorrectComponent implements OnInit {
     this.query$.subscribe(query => {
       if (query) {
             this.sugflag = false;
-            this.autocorrectservice.getsearchresults(query).subscribe(res => {
+            this.isQues = false;
+            this.isQues = query.substr (query.length - 1) === '?';
+            this.autocorrectservice.getsearchresults (query.replace (/[?!]/g , "")).subscribe (res => {
                 if (res) {
-                    if (res['original'].toLocaleLowerCase() !== res['suggestion'].toLocaleLowerCase()) {
+                    if ( res['original'].replace(/[.,?!]/g , "").toLocaleLowerCase() !== res['suggestion'].replace(/[.,?!]/g , "").toLocaleLowerCase()) {
                         this.sugflag = true;
-                        this.suggestion = res['suggestion'];
+                        this.suggestion = this.isQues === true ? res['suggestion'] + '?' : res['suggestion'];
                       }
                     }
               });


### PR DESCRIPTION
Fixes issue #617 

Changes: question mark in the query is not shown as incorrect

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
Before:
![image](https://user-images.githubusercontent.com/20185076/27961677-20f154be-634d-11e7-9520-18801e929506.png)

After:
![image](https://user-images.githubusercontent.com/20185076/27961596-d80226de-634c-11e7-8b4a-7eebdb54de01.png)
