### PR TITLE
Fixes #625, Search bar and tabs position adjusted accordingly

### DIFF
--- a/src/app/index/index.component.ts
+++ b/src/app/index/index.component.ts
@@ -23,7 +23,7 @@ export class IndexComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.searchdata.timezoneOffset = new Date().getTimezoneOffset();
+    document.getElementById('nav-group').style.width = '584px';
   }
 
 }

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -457,6 +457,15 @@ div.video-result {
   #search-options li {
     padding: 0px 2.3% 12px;
   }
+  #search-options-field{
+    padding-top: 8%;
+  }
+  #settings{
+    left: 4.5%;
+  }
+  #tools{
+    left: 4.5%;
+  }
 }
 
 @media screen and (max-width:741px) {
@@ -468,11 +477,7 @@ div.video-result {
   }
 }
 
-@media screen and (max-width:546px) {
-  .result {
-    margin-left: 13%;
-  }
-}
+
 
 @media screen and (max-width:639px) {
   #search-options li {
@@ -480,7 +485,25 @@ div.video-result {
   }
 }
 
-@media screen and (max-width:479px) {
+@media screen and (max-width:560px) {
+  .result {
+    margin-left: 13%;
+  }
+  li.dropdown{
+    left:0;
+  }
+  #settings{
+    left:0;
+  }
+  #tools{
+    left:0;
+  }
+  #search-options li{
+    padding-left: 5vw;
+    padding-right: 5vw;
+  }
+}
+@media screen and (max-width:495px) {
   .result {
     margin-left: 12%;
     padding-right: 20px;
@@ -495,18 +518,18 @@ div.video-result {
     margin-left: 7%;
   }
   #search-options li {
-    padding: 0px 0.5% 12px;
+    padding: 0px 4vw 12px;
   }
 }
 
 @media screen and (max-width:379px) {
   #search-options li {
-    padding: 0px 6.2% 12px;
+    padding: 0px 3vw 12px;
   }
 }
 
-@media screen and (max-width:320px) {
+@media screen and (max-width:330px) {
   #search-options li {
-    padding: 0px 5.6% 12px;
+    padding: 0px 2vw 12px;
   }
 }

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -187,6 +187,5 @@ export class ResultsComponent implements OnInit {
   }
 
   ngOnInit() {
-    document.getElementById('nav-group').style.width = '632px';
   }
 }

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -1,6 +1,6 @@
 #nav-group{
   background-color: white;
-  width: 584px;
+  width: 632px;
   color: black;
   height: 44px;
   border-radius: 2px;
@@ -82,41 +82,27 @@
     width: 50vw;
   }
 }
-
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 862px) and (min-width: 768px){
   #nav-group {
-    margin-left: 19%;
-    width: 120%;
+    left: -26%
+  }
+}
+  @media screen and (max-width: 767px) {
+  #nav-group {
+    margin-left: -15vw;
+    width: 95vw;
+    margin-top: 11%;
+
   }
   .align-search-btn{
     left: -9%;
   }
 }
 
-@media screen and (max-width: 601px) {
-  #nav-group {
-    width: 123%;
-  }
-}
-
-@media screen and (max-width:567px) {
-  #nav-group {
-    width: 120%;
-  }
-}
-
-@media screen and (max-width:517px) {
-  #nav-group {
-    left: 5%;
-  }
-}
 
 @media screen and (max-width: 480px) {
   .align-search-btn{
     left: -6%;
-  }
-  #nav-group {
-    margin-left: 15%;
   }
 }
 
@@ -133,11 +119,8 @@
 }
 
 @media screen and (max-width: 503px) {
-  #nav-group {
-    width: 5px;
-  }
   #nav-input {
-    width: 80vw;
+    width: 80%;
   }
 }
 


### PR DESCRIPTION
Fixes issue #625 

Changes: search bar and tabs position adjusted accordingly for mobile version of the site

Demo Link: [https://marauderer97.github.io/susper.com/](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/27996648-31bc7112-6504-11e7-98b8-bcf58140599e.png)
![image](https://user-images.githubusercontent.com/20185076/27996650-3e8d998e-6504-11e7-904a-e3945b6f7104.png)
![image](https://user-images.githubusercontent.com/20185076/27996654-54aef852-6504-11e7-973d-8352d34f6b9c.png)
![image](https://user-images.githubusercontent.com/20185076/27996658-605306da-6504-11e7-9fdc-a7c9764e6872.png)
![image](https://user-images.githubusercontent.com/20185076/27996661-6f826baa-6504-11e7-8c60-224f8f5be008.png)


NOTE: There is a problem, notice the line in the .ts file, where the nav-group width is set inside ngInit, This is a bad practice since the width is then permanently set, so I wrote a function, to first check the document width, however this function only runs once when the page is initialized, so it can still cause problems.
@nikhilrayaprolu @harshit98 I would like suggestions on this.
My only options were either to add !important to the other widths to make it responsive, or remove that line setting width to 632px.