### PR TITLE
Fixes #623, Intelligence is displayed only on the first page

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -52,7 +52,7 @@
               <app-auto-correct [hidden]="hideAutoCorrect"></app-auto-correct>
             </div>
       <div class="result">
-      <app-intelligence></app-intelligence>
+      <app-intelligence [hidden]="hideAutoCorrect"></app-intelligence>
       </div>
             <div *ngFor="let item of items$|async" class="result">
                 <div class="title">

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -158,13 +158,12 @@ export class ResultsComponent implements OnInit {
       this.presentPage = Math.abs(query['start'] / urldata.rows) + 1;
       let querydata = Object.assign({}, urldata);
       this.store.dispatch(new queryactions.QueryServerAction(querydata));
-    });
       if (this.presentPage === 1) {
         this.hideAutoCorrect = 0;
       } else {
         this.hideAutoCorrect = 1;
       }
-
+    });
     this.items$ = store.select(fromRoot.getItems);
     this.responseTime$ = store.select(fromRoot.getResponseTime);
     this.responseTime$.subscribe(responsetime => {


### PR DESCRIPTION
Fixes issue #623 

Changes: Intelligence is displayed only on the first page

Demo Link: [Here](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
On page 1:
![image](https://user-images.githubusercontent.com/20185076/28005419-17f97ac2-6568-11e7-97e3-d77ca9a289b5.png)

On page 2:
![image](https://user-images.githubusercontent.com/20185076/28005430-2d50f3dc-6568-11e7-9108-33639661f112.png)
