### PR TITLE
Fixes #629, Info box is displayed only on the first page

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -69,7 +69,7 @@
         </div>
     </div>
 
-  <app-infobox [hidden]="hidefooter" class="infobox col-md-4" *ngIf="Display('all')"></app-infobox>
+  <app-infobox [hidden]="hidefooter || hideAutoCorrect" class="infobox col-md-4" *ngIf="Display('all')"></app-infobox>
   <!-- END -->
     <!-- Image section -->
     <div class="container">

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -158,12 +158,13 @@ export class ResultsComponent implements OnInit {
       this.presentPage = Math.abs(query['start'] / urldata.rows) + 1;
       let querydata = Object.assign({}, urldata);
       this.store.dispatch(new queryactions.QueryServerAction(querydata));
-    });
       if (this.presentPage === 1) {
         this.hideAutoCorrect = 0;
       } else {
         this.hideAutoCorrect = 1;
       }
+    });
+
 
     this.items$ = store.select(fromRoot.getItems);
     this.responseTime$ = store.select(fromRoot.getResponseTime);


### PR DESCRIPTION
Fixes issue #629 
Changes: Info box is displayed only on the first page

Demo Link: [https://marauderer97.github.io/susper.com/](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
No infobox from the second page onwards
![image](https://user-images.githubusercontent.com/20185076/28006226-0a5e86e2-656c-11e7-8131-ee88ae8ef390.png)
