### PR TITLE
Fixes #642, Autocorrect message hidden when empty

### DIFF
--- a/src/app/auto-correct/auto-correct.component.ts
+++ b/src/app/auto-correct/auto-correct.component.ts
@@ -36,7 +36,7 @@ export class AutoCorrectComponent implements OnInit {
             this.sugflag = false;
 
             if (res) {
-              if ( res['original'].replace(/[.,?!]/g , "").toLocaleLowerCase() !== res['suggestion'].replace(/[.,?!]/g , "").toLocaleLowerCase()) {
+              if ( res['original'].replace(/[.,?!]/g , "").toLocaleLowerCase() !== res['suggestion'].replace(/[.,?!]/g , "").toLocaleLowerCase() && res['suggestion'] !== '') {
                 this.sugflag = true;
                 this.suggestion = this.isQues === true ? res['suggestion'] + '?' : res['suggestion'];
               } else {


### PR DESCRIPTION
Fixes issue #642 
Changes:Autocorrect message hidden when empty

Demo Link: [https://marauderer97.github.io/susper.com/](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/20185076/28186779-0804bfd0-683a-11e7-874e-0d60c21e4fa9.png)
