### PR TITLE
Fixes #664: Longer suggestions in related searches

### DIFF
--- a/src/app/related-search/related-search.component.css
+++ b/src/app/related-search/related-search.component.css
@@ -1,7 +1,7 @@
 .card{
   padding-left: 50px;
   padding-top: 10px;
-  max-width: 450px;
+  max-width: 850px;
 }
 
 .container {
@@ -12,7 +12,7 @@
 }
 
 .heading {
-  padding-bottom: 8px;
+  margin-left: 4%;
   color: #222;
   font-size: 18px;
   font-family: Arial, sans-serif;
@@ -21,7 +21,7 @@
 .related{
   margin-top: 10px;
   display: inline-block;
-  width: 180px;
+  width: 380px;
   float: left;
 }
 
@@ -30,6 +30,7 @@
   text-decoration: none;
   font-family: Arial, sans-serif;
   font-size: 14px;
+  white-space: nowrap;
 }
 
 .rellink:hover{

--- a/src/app/related-search/related-search.component.html
+++ b/src/app/related-search/related-search.component.html
@@ -1,8 +1,8 @@
 <div class="container">
+  <h3 class="heading">Searches related to {{this.keyword}}</h3>
   <div *ngIf="results?.length > 0" class="card">
-    <h3 class="heading">Searches related to {{this.keyword}}</h3>
-    <div *ngFor="let result of results" class="related">
-      <a [routerLink]="resultsearch" [queryParams]="{query: result.label}" class="rellink">{{result.label}}</a>
-    </div>
+      <div *ngFor="let result of results" class="related">
+        <a [routerLink]="resultsearch" [queryParams]="{query: result.label}" class="rellink">{{result.label}}</a>
+      </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes issue #664 

Changes: 
- Now longer suggestion in related searches appears clearly without any text wrapping.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

![screenshot from 2017-07-18 16-11-00](https://user-images.githubusercontent.com/22245418/28313583-088307ca-6bd5-11e7-8d48-99b667de20aa.png)

Kindly review @nikhilrayaprolu @Marauderer97 

