### PR TITLE
Fixes #662, Makes drop down responsive on results and index page

### DIFF
--- a/src/app/dropdown/dropdown.component.css
+++ b/src/app/dropdown/dropdown.component.css
@@ -1,6 +1,16 @@
 li.dropdown-menu-box {
     top: 10px;
 }
+.menu-row{
+  width: 267px;
+  grid-template-columns: 1fr 1fr 1fr;
+  background-color: white;
+}
+
+.menu-item{
+  display: inline-block;
+  width: 86px;
+}
 .dropdown-menu{
   height: 500px;
   width: 327px;
@@ -117,3 +127,16 @@ hr {
     padding-top: 10px;
 }
 
+@media screen and (max-width: 767px) {
+  #small-drop{
+    position: absolute;
+    background-color: white;
+    border: 1px solid #cccccc;
+    right: -38px;
+    left: auto;
+  }
+  .nav > li > a{
+    padding-left: 11px;
+    padding-right: 28px;
+  }
+}

--- a/src/app/dropdown/dropdown.component.html
+++ b/src/app/dropdown/dropdown.component.html
@@ -4,10 +4,10 @@
       <a href="#" data-toggle="dropdown" class="dropdown-toggle" data-proofer-ignore>
         <i class="glyphicon glyphicon-th" style="font-size: 1.5em"></i>
       </a>
-      <div class="dropdown-menu">
+      <div id="small-drop" class="dropdown-menu">
         <!--First row starts from here-->
-        <div class="row">
-          <div class="col-sm-4">
+        <div class="menu-row">
+          <div class="menu-item">
             <div class="block">
               <a href="//blog.fossasia.org" target="_blank">
                 <img src="../../assets/images/blog.png">
@@ -15,7 +15,7 @@
               </a>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="menu-item">
             <div class="block">
               <a href="//github.com/fossasia/susper.com" target="_blank">
                 <img src="../../assets/images/code.png">
@@ -23,7 +23,7 @@
               </a>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="menu-item">
             <div class="block">
               <a href="//github.com/fossasia/susper.com" target="_blank">
                 <img src="../../assets/images/github.png">
@@ -34,8 +34,8 @@
         </div>
         <!--First row ends up here-->
         <!--Second row starts from here-->
-        <div class="row">
-          <div class="col-sm-4">
+        <div class="menu-row">
+          <div class="menu-item">
             <div class="block">
               <a href="//github.com/fossasia/susper.com/issues" target="_blank">
                   <img src="../../assets/images/bug.png">
@@ -46,7 +46,7 @@
                 </a>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="menu-item">
             <div class="block">
               <a routerLink="/contact" routerLinkActive="active">
                   <img src="../../assets/images/contact.png">
@@ -54,7 +54,7 @@
                 </a>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="menu-item">
             <div class="block">
               <a routerLink="/advancedsearch" routerLinkActive="active">
                   <img src="../../assets/images/search.png">
@@ -67,8 +67,8 @@
         <!--Second row ends up here-->
         <hr size="20">
         <!--Third row starts from here-->
-        <div class="row">
-          <div class="col-sm-4">
+        <div class="menu-row">
+          <div class="menu-item">
             <div class="block" id="fossasia-logo">
               <a href="//fossasia.org" target="_blank">
                   <img src="../../assets/images/fossasia.png" style="width: 68px; height: 46px" class="fossasia">
@@ -76,7 +76,7 @@
                 </a>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="menu-item">
             <div class="block" id="loklak-logo">
               <a href="//loklak.net" target="_blank">
                 <img src="../../assets/images/loklak.png" class="loklak">
@@ -84,7 +84,7 @@
               </a>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="menu-item">
             <div class="block" id="susi-logo">
               <a href="//chat.susi.ai" target="_blank">
                 <img src="../../assets/images/susi.jpg" class="susi">
@@ -95,7 +95,7 @@
         </div>
         <!--Third row ends up here-->
         <!--Fourth row starts from here-->
-        <div class="row">
+        <div class="menu-row">
           <div class="block" id="eventyay" style="width: 110px; height: 62px">
             <a href="//eventyay.com" target="_blank">
               <img src="../../assets/images/eventyay.png" class="eventyay">
@@ -104,7 +104,7 @@
           </div>
         </div>
         <hr size="20">
-        <div class="row" id="labs">
+        <div class="menu-row" id="labs">
           <a href="//labs.fossasia.org" target="_blank" class="lab-link">More on labs.fossasia.org</a>
         </div>
       </div>

--- a/src/app/index/index.component.css
+++ b/src/app/index/index.component.css
@@ -152,7 +152,7 @@ footer {
     margin-left: 37%;
   }
   #dropdown-icon {
-    margin-left: 95vw;
+    margin-left: 93vw;
   }
   }
 

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -19,7 +19,7 @@
 #navbar-dropdown-box{
   float: right;
   min-width: 45px;
-  margin-right: 7px;
+  margin-right: 20px;
 }
 .navbar-default{
   border-bottom: none;
@@ -86,12 +86,14 @@
   #navbar-search {
     margin-left: -5%;
   }
-  #navbar-dropdown-box{
-    display: none;
+
+}
+@media screen and (max-width:800px) {
+  #navbar-dropdown-box {
+    margin-top: -36px;
   }
 }
-
-@media screen and (max-width:768px) {
+@media screen and (max-width:767px) {
   .top-nav{
     margin-top: -8%;
   }
@@ -104,6 +106,10 @@
   }
   .align-navsearch-btn {
     margin-right: 1% !important;
+  }
+  #navbar-dropdown-box{
+    margin-right: 32px;
+    margin-top: -116px;
   }
 }
 


### PR DESCRIPTION

Fixes issue #662 

Changes: Makes drop down responsive on results and index page

Demo Link:[https://marauderer97.github.io/susper.com/](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/20185076/28362256-5ea64300-6c99-11e7-9832-dab49f7b97ab.png)
![image](https://user-images.githubusercontent.com/20185076/28362273-6d6ff872-6c99-11e7-91d5-4fdb1e047516.png)
NOTE: From 819 px to 768 px, the drop down slightly overlaps with the search bar, because of the page layout, please suggest solutions
The ones I could think of so far: 
1. Reduce the size of the drop down icon in that interval
2. Reduce the size of the search bar slightly in that interval.
@harshit98 @nikhilrayaprolu Please review