### PR TITLE
Fixes #669 Result page made responsive

### DIFF
--- a/src/app/auto-correct/auto-correct.component.css
+++ b/src/app/auto-correct/auto-correct.component.css
@@ -3,14 +3,12 @@
   font-weight: 500;
   color: navy;
   padding-top: 3%;
-  padding-left: 5.9%;
 }
 
 .mean {
   font-size: 18px;
   color: #dd4b39;
   font-weight: normal;
-  padding-left: 2px;
   margin-bottom: -2px;
 }
 

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -293,7 +293,7 @@ a {
 #setting-dropdown{
   margin-top: 8%;
   margin-left: 15%;
-  border-radius: 0px;
+  border-radius: 0;
 }
 
 #tool-dropdown{
@@ -361,6 +361,10 @@ div.video-result {
   margin-left: 8.6%;
 }
 
+div.autocorrect{
+  margin-left: 6%;
+}
+
 @media screen and (min-width:1920px) {
   #tools {
     margin-left: 27%;
@@ -405,7 +409,7 @@ div.video-result {
     margin-left: 8.2%;
   }
   div.autocorrect {
-    margin-left: 2%;
+    margin-left: 8.2%;
   }
 }
 
@@ -429,7 +433,7 @@ div.video-result {
     margin-left: 8.7%;
   }
   div.autocorrect {
-    margin-left: 2.7%;
+    margin-left: 8.7%;
   }
 }
 
@@ -459,6 +463,9 @@ div.video-result {
   div.result.message-bar {
     margin-left: 9%;
   }
+  div.autocorrect{
+    margin-left: 9%;
+  }
 }
 
 @media screen and (max-width:882px) {
@@ -481,7 +488,7 @@ div.video-result {
 
 @media screen and (max-width:767px) {
   div.result {
-    margin-left: 1%;
+    margin-left: 4%;
     padding-right: 30px;
   }
   .message-bar {
@@ -494,6 +501,7 @@ div.video-result {
   }
   #pag-bar {
     padding-left: 50px;
+    margin-left: 0;
   }
   #search-tools {
     padding-left: 50px;
@@ -510,46 +518,42 @@ div.video-result {
   #tools{
     left: 4.5%;
   }
+  #setting-dropdown{
+    min-width: 100px;
+    margin-left: 0;
+  }
+  #setting-dropdown li{
+    padding-left: 0;
+  }
+  div.result.message-bar{
+    margin-left: 4%;
+  }
+  div.autocorrect{
+    margin-left: 4%;
+    padding-left: 0;
+  }
+  #tool-dropdown{
+    right: 0;
+    margin-left: -58%;
+    min-width: 123px;
+  }
 }
 
 @media screen and (max-width: 760px) {
 
-  div.result {
-    margin-left: 10%;
-    padding-right: 30px;
-  }
-
-  div.result.message-bar {
-    margin-left: 10%
-  }
   .feed.col-md-10.col-md-offset-1.col-sm-10.col-sm-offset-1.col-lg-10.col-lg-offset-1 {
     width: 100%;
     margin-left: -2%;
   }
-  div.autocorrect{
-    margin-left: 4%;
-  }
 }
 
 @media screen and (max-width:741px) {
-  div.result {
-    margin-left: 10.5%;
-  }
-  div.autocorrect {
-    margin-left: 3.5%;
-  }
   .feed {
     width: 87%;
   }
 }
 
 @media screen and (max-width: 730px) {
-  div.result.message-bar {
-    margin-left: 10%;
-  }
-  div.autocorrect {
-    margin-left: 3.3%;
-  }
   .feed.col-md-10.col-md-offset-1.col-sm-10.col-sm-offset-1.col-lg-10.col-lg-offset-1 {
     width: 100%;
     margin-left: -2%;
@@ -559,6 +563,10 @@ div.video-result {
 @media screen and (max-width:639px) {
   #search-options li {
     padding: 0px 1.5% 12px;
+  }
+  #tool-dropdown li{
+    padding-left: 0!important;
+    padding-right: 0!important;
   }
 }
 
@@ -579,14 +587,21 @@ div.video-result {
     padding-left: 5vw;
     padding-right: 5vw;
   }
+  #setting-dropdown li{
+    padding-left: 0!important;
+    padding-right: 0!important;
+  }
+  #tool-dropdown li{
+    padding-left: 0!important;
+    padding-right: 0!important;
+  }
 }
 @media screen and (max-width:495px) {
   .result {
-    margin-left: 12%;
     padding-right: 20px;
   }
   #pag-bar {
-    padding-left: 30px;
+    padding-left: 10px;
   }
   #search-tools {
     padding-left: 30px;
@@ -603,18 +618,24 @@ div.video-result {
   .feed.col-md-10.col-md-offset-1.col-sm-10.col-sm-offset-1.col-lg-10.col-lg-offset-1 {
     width: 100%;
   }
-  div.result.message-bar {
-    margin-left: 12%;
-  }
   div.autocorrect{
-    margin-left: 5%;
     top: 2%;
   }
-    div.result {
-      margin-left: 12.5%;
-    }
 }
-
+@media screen and (max-width:423px) {
+  #pag-bar {
+    padding-left: 0;
+  }
+  .page-text {
+    font-size: x-large;
+  }
+  .page-item span{
+    font-size: 10px;
+  }
+  .arrow {
+    font-size: small;
+  }
+}
 @media screen and (max-width:379px) {
   #search-options li {
     padding: 0px 3vw 12px;

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -89,20 +89,33 @@
     width: 95vw!important;
   }
   .align-search-btn{
-    left: -9%;
+    left: -1%;
+  }
+    #nav-input {
+      width: 83vw;
+    }
+}
+@media screen and (max-width: 573px){
+  .align-search-btn{
+    left: -5%;
+  }
+  #nav-input {
+    width: 73vw;
   }
 }
 
-
 @media screen and (max-width: 480px) {
   .align-search-btn{
-    left: -6%;
+    left: -10%;
   }
 }
 
 @media screen and (max-width: 360px) {
   .align-search-btn{
-    left: -5%;
+    left: -15%;
+  }
+  #nav-input {
+    width: 63vw;
   }
 }
 


### PR DESCRIPTION
Fixes issue #669 

Changes:
 Result page made responsive

- [x] Search bar made responsive

- [x] Results made responsive

- [x] Fixing pagination bar position

- [x] made tools dropdown responsive until 290px

Demo Link: [https://marauderer97.github.io/susper.com/](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/28415137-11fda4f2-6d6c-11e7-9c4d-1064c7dd1922.png)
![image](https://user-images.githubusercontent.com/20185076/28415149-1dcb5eaa-6d6c-11e7-8689-c2650caba718.png)
![image](https://user-images.githubusercontent.com/20185076/28415169-318a3aba-6d6c-11e7-8360-bc9424e6adad.png)

@harshit98 The images are not displayed properly in mobile view, but I didnot want to tamper with the changes you made for uniform height, since I am afraid I might tamper with the uniformity, would you like to handle this?