### PR TITLE
Fixes #668 disable microphone on smallerscreen devices

### DIFF
--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -85,6 +85,9 @@
   }
 }
   @media screen and (max-width: 767px) {
+    .microphone {
+      display: none;
+    }
   #nav-group {
     width: 95vw!important;
   }


### PR DESCRIPTION
Fixes issue #668 
Google doesn't have speech feature in chrome browser in mobile phones, disabled microphone similar to market leader on small screens


Demo Link: https://susper-pr-693.herokuapp.com/
Screenshots for the change: 
![image](https://user-images.githubusercontent.com/15216503/28755876-3c4c7c5c-7581-11e7-805a-42f78b64efaa.png)
