### PR TITLE
Fixes #680: Search icon appears for small, medium and large mobile screen sizes

### DIFF
--- a/src/app/index/index.component.html
+++ b/src/app/index/index.component.html
@@ -1,4 +1,3 @@
-
 <div class="container-fluid">
     <div class="starter-template">
         <div id="search-bar">

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -106,22 +106,15 @@
 
 @media screen and (max-width: 480px) {
   .align-search-btn{
-    left: -10%;
+    left: -1%;
   }
 }
 
 @media screen and (max-width: 360px) {
   .align-search-btn{
-    left: -15%;
+    left: -1%;
   }
   #nav-input {
     width: 63vw;
-  }
-}
-
-
-@media screen and (max-width: 652px) {
-  #nav-input {
-    width: 83vw;
   }
 }


### PR DESCRIPTION
Addresses #680 

Changes: 
- Search icon appears for mobile screen size S-320px
- Search icon appears for mobile screen size M-375px
- Search icon appears for mobile screen size L-425px

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

Small
![screenshot from 2017-08-02 20-07-05](https://user-images.githubusercontent.com/22245418/28879070-c0bb628e-77be-11e7-8a12-19f7fd250865.png)

Medium
![screenshot from 2017-08-02 20-20-54](https://user-images.githubusercontent.com/22245418/28879740-9044c404-77c0-11e7-89fb-491f0cd20de5.png)

Large
![screenshot from 2017-08-02 20-38-50](https://user-images.githubusercontent.com/22245418/28880446-af9ace50-77c2-11e7-86cf-47aa84f204db.png)


Kindly review @nikhilrayaprolu @Marauderer97 
