### PR TITLE
Addresses #647 and #668: Make speech UI responsive on homepage for various screen sizes

### DIFF
--- a/src/app/speechtotext/speechtotext.component.css
+++ b/src/app/speechtotext/speechtotext.component.css
@@ -10,13 +10,14 @@
   width: 100%;
   z-index: 10000;
   transition:visibility 0s linear 0.218s,opacity 0.218s,background-color 0.218s;
-
 }
+
 .s2fp.spch {
   opacity: 1;
   visibility: visible;
   transition-delay: 0s;
 }
+
 .s2fp .spchc, .s2fp-h .spchc {
   margin: auto;
   margin-top: 312px;
@@ -26,16 +27,19 @@
   position: relative;
   top: 0;
 }
+
 .spchc {
   display: block;
   height: 42px;
   position: absolute;
   pointer-events: none;
 }
+
 .spch {
   text-align: left;
   visibility: hidden;
 }
+
 .close-button {
   color: #777;
   cursor: pointer;
@@ -50,12 +54,14 @@
   top: 0;
   width: 15px;
 }
+
 ._o3 {
   height: 100%;
   pointer-events: none;
   width: 100%;
   transition: opacity .318s ease-in;
 }
+
 ._AM {
   height: 165px;
   right: -270px;
@@ -66,12 +72,14 @@
   position: relative;
   transition: transform 0.218s,opacity 0.218s ease-in;
 }
+
 .s2tb.spch {
   background: rgba(255,255,255,0);
   opacity: 1;
   visibility: visible;
   transition-delay: 0s;
 }
+
 .s2tb .spchc, .s2tb-h .spchc {
   background: #fff;
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);
@@ -81,17 +89,20 @@
   padding: 51px 0 85px 126px;
   position: absolute;
 }
+
 .s2tb-h ._o3, .s2tb ._o3 {
   height: 100%;
   width: 572px;
   transition: opacity .318s ease-in;
 }
+
 .s2tb-h ._AM, .s2tb ._AM {
   height: 95px;
   right: -31px;
   top: -27px;
   width: 95px;
 }
+
 .s2fp .button, .s2tb .button {
   opacity: 1;
   pointer-events: auto;
@@ -99,11 +110,13 @@
   transform: scale(1);
   transition-delay: 0;
 }
+
 .s2tb-h ._wPb, .s2tb ._wPb {
   left: 17px;
   top: 7px;
   transform: scale(.53);
 }
+
 ._CMb {
   background-color: #dbdbdb;
   border-radius: 100%;
@@ -118,11 +131,13 @@
   transform: scale(0.1);
   transition: all .03s ease-in-out;
 }
+
 .s2fp-h .button {
   pointer-events: none;
   position: absolute;
   transition-delay: 0;
 }
+
 .button {
   background-color: #fff;
   border: 1px solid #eee;
@@ -138,6 +153,7 @@
   top: 0;
   transition: background-color 0.218s,border 0.218s,box-shadow 0.218s;
 }
+
 ._wPb {
   height: 87px;
   left: 43px;
@@ -147,6 +163,7 @@
   width: 42px;
   transform: scale(1);
 }
+
 ._AUb {
   background-color: #999;
   border-radius: 30px;
@@ -156,6 +173,7 @@
   position: absolute;
   width: 24px;
 }
+
 ._Fjd {
   bottom: 0;
   height: 53px;
@@ -165,6 +183,7 @@
   position: absolute;
   width: 52px;
 }
+
 ._oXb {
   background-color: #999;
   bottom: 14px;
@@ -175,6 +194,7 @@
   width: 9px;
   z-index: 1;
 }
+
 ._dWb {
   border: 7px solid #999;
   border-radius: 28px;
@@ -196,7 +216,6 @@
   -webkit-font-smoothing: antialiased;
   transition: opacity .1s ease-in,margin-left .5s ease-in,top 0s linear 0.218s;
   -webkit-animation: typing 2s steps(21,end), blink-caret .5s step-end infinite alternate;
-  white-space: nowrap;
   overflow: hidden;
   animation-delay: 3.5s;
 }
@@ -207,12 +226,24 @@
   top: -.2em;
   width: 460px;
 }
+
 .s2tb-h .spcht, .s2tb .spcht {
   font-size: 27px;
   left: 7px;
   top: .2em;
   width: 490px;
 }
+
 .s2tb-h ._gjb, .s2tb ._gjb {
   position: relative;
+}
+
+@media screen and (max-width: 425px) {
+  .spcht {
+    margin-left: 10%;
+    margin-top: -40%;
+  }
+  ._AM {
+    right: 44px;
+  }
 }


### PR DESCRIPTION
Addresses issue #647 and #668  

Changes: Made speech UI responsive on the homepage for following mobile screen sizes: 
- S-320px
- M-375px
- L-425px

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

Small
![screenshot from 2017-08-03 08-24-10](https://user-images.githubusercontent.com/22245418/28904024-c073d97a-7825-11e7-8cff-a01d06556d25.png)

Medium
![screenshot from 2017-08-03 08-24-36](https://user-images.githubusercontent.com/22245418/28904029-c40e467e-7825-11e7-88d5-5048d200d77a.png)

Large
![screenshot from 2017-08-03 08-24-47](https://user-images.githubusercontent.com/22245418/28904032-c887cc7a-7825-11e7-9d23-92f81ee5cffb.png)

Kindly review @nikhilrayaprolu @Marauderer97. Let me know if any changes have to be done.

@nikhilrayaprolu I am not able to make it responsive on results page though. Can you look into this issue and make a separate PR for it? :)