### PR TITLE
Addresses #524: Susper responsive on mobile small screen size 320px

### DIFF
--- a/src/app/footer-navbar/footer-navbar.component.css
+++ b/src/app/footer-navbar/footer-navbar.component.css
@@ -71,3 +71,9 @@ div a:active{
   text-decoration: underline;
   background-color: white;
 }
+
+@media screen and (max-width: 320px) {
+  div.footer-bar {
+    width: 102%;
+  }
+}

--- a/src/app/index/index.component.css
+++ b/src/app/index/index.component.css
@@ -171,9 +171,9 @@ footer {
   }
 }
 
-@media screen and (max-width: 479px) {
+@media screen and (max-width: 320px) {
   img#biglogo{
-    margin-left: 52%;
+    margin-left: 49%;
   }
 }
 

--- a/src/app/related-search/related-search.component.css
+++ b/src/app/related-search/related-search.component.css
@@ -35,3 +35,12 @@
 .rellink:hover{
   text-decoration: underline;
 }
+
+@media screen and (max-width: 320px) {
+  h3.heading {
+    margin-left: -11%;
+  }
+  div.related {
+    margin-left: -11%;
+  }
+}

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -515,9 +515,6 @@ div.autocorrect{
   #search-options li {
     padding: 0px 2.3% 12px;
   }
-  #search-options-field{
-    padding-top: 8%;
-  }
   #settings{
     left: 4.5%;
   }
@@ -530,9 +527,6 @@ div.autocorrect{
   }
   #setting-dropdown li{
     padding-left: 0;
-  }
-  div.result.message-bar{
-    margin-left: 4%;
   }
   div.autocorrect{
     margin-left: 4%;
@@ -612,26 +606,17 @@ div.autocorrect{
   #search-tools {
     padding-left: 30px;
   }
-  #search-options {
-    margin-left: 7%;
-  }
   #search-options li {
     padding: 0px 4vw 12px;
   }
 }
 
 @media screen and (max-width: 460px) {
-  .feed.col-md-10.col-md-offset-1.col-sm-10.col-sm-offset-1.col-lg-10.col-lg-offset-1 {
-    width: 100%;
-  }
   div.autocorrect{
     top: 2%;
   }
 }
 @media screen and (max-width:423px) {
-  #pag-bar {
-    padding-left: 0;
-  }
   .page-text {
     font-size: x-large;
   }
@@ -651,5 +636,25 @@ div.autocorrect{
 @media screen and (max-width:330px) {
   #search-options li {
     padding: 0px 2vw 12px;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  #search-options {
+    margin-left: 0.3%;
+  }
+  .feed.col-md-10.col-md-offset-1.col-sm-10.col-sm-offset-1.col-lg-10.col-lg-offset-1 {
+    width: 100%;
+    margin-left: 2%;
+  }
+  div.result.message-bar{
+    margin-left: 7%;
+  }
+  #search-options-field{
+    padding-top: 8%;
+    width: 91.5%;
+  }
+  #pag-bar {
+    margin-left: 5%;
   }
 }


### PR DESCRIPTION
Addresses issue #524 

Changes: Made Susper responsive on smaller mobile screen size (320px)

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

(Not applicable here, since there will be too many screenshots)

@mariobehling @nikhilrayaprolu @Marauderer97 Please review carefully checking all the features. Let me know if some changes have to be done or not. 