### PR TITLE
Fixes #714 results are displayed according to date or context rating

### DIFF
--- a/src/app/auto-correct/auto-correct.component.ts
+++ b/src/app/auto-correct/auto-correct.component.ts
@@ -27,7 +27,7 @@ export class AutoCorrectComponent implements OnInit {
     this.resultscomponentchange$ = store.select(fromRoot.getItems);
     this.resultscomponentchange$.subscribe(resp => {
       this.query$.subscribe(query => {
-        if (query) {
+        if (query && !query.includes('/date')) {
           this.sugflag = false;
 
           this.isQues = false;

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -64,13 +64,13 @@ export class ResultsComponent implements OnInit {
 
   filterByDate() {
     let urldata = Object.assign({}, this.searchdata);
-    urldata.sort = 'last_modified desc';
+    urldata.query += ' /date';
     this.store.dispatch(new queryactions.QueryServerAction(urldata));
   }
 
   filterByContext() {
     let urldata = Object.assign({}, this.searchdata);
-    delete urldata.sort;
+    urldata.query = urldata.query.replace("/date", "");
     this.store.dispatch(new queryactions.QueryServerAction(urldata));
   }
 


### PR DESCRIPTION
Fixes issue #714 

Changes: Made the sorting work similar to http://search.yacy.net/
Demo Link: http://susper-pr-721.herokuapp.com

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/15216503/29025230-5f341dac-7b93-11e7-8fdd-9e319a6f6a65.png)

