### PR TITLE
Fixes #716: Made dropdown menu responsive for screen size 768px

### DIFF
--- a/src/app/dropdown/dropdown.component.css
+++ b/src/app/dropdown/dropdown.component.css
@@ -1,6 +1,7 @@
 li.dropdown-menu-box {
     top: 10px;
 }
+
 .menu-row{
   width: 267px;
   grid-template-columns: 1fr 1fr 1fr;
@@ -11,6 +12,7 @@ li.dropdown-menu-box {
   display: inline-block;
   width: 86px;
 }
+
 .dropdown-menu{
   height: 500px;
   width: 327px;
@@ -39,11 +41,13 @@ li.dropdown-menu-box {
   border-left: 6px solid transparent;
   content: '';
 }
+
 div.block:hover {
     border: 1px solid rgba(150,150,150,0.3);
 }
+
 div.block{
-  text-align: center;
+    text-align: center;
 }
 
 p {
@@ -125,6 +129,13 @@ p.contact-text {
 
 hr {
     padding-top: 10px;
+}
+
+@media screen and (max-width: 768px) {
+    .dropdown-menu-box {
+        margin-left: 60%;
+        margin-top: 60%;
+    }
 }
 
 @media screen and (max-width: 767px) {

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -399,6 +399,7 @@ div.autocorrect{
     margin-left: 118px;
   }
 }
+
 @media screen and (max-width:767px) {
   div.result {
     padding-right: 30px;

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -12,7 +12,6 @@
   float: left;
 }
 
-
 #nav-input{
   font-size: 16px;
   font-weight: 400;
@@ -84,16 +83,17 @@
   width: 100px;
   }
 }
-  @media screen and (max-width: 767px) {
+
+@media screen and (max-width: 767px) {
   #nav-group {
     width: 95vw!important;
   }
   .align-search-btn{
     left: -1%;
   }
-    #nav-input {
-      width: 83vw;
-    }
+  #nav-input {
+    width: 83vw;
+  }
 }
 @media screen and (max-width: 573px){
   .align-search-btn{


### PR DESCRIPTION
Fixes issue #716 

Changes: 
- Made drop-down menu responsive.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

![screenshot from 2017-08-09 19-38-40](https://user-images.githubusercontent.com/22245418/29129559-d290c3ba-7d44-11e7-8fa3-d7507d8e6087.png)

@Marauderer97 @nikhilrayaprolu Please review. There was only option to add a seperate`@media` for 768px. Changing 767px code would have affected a lot of UI. 