### PR TITLE
Fixes #711: Removes flickering of text-animation

### DIFF
--- a/src/app/speechtotext/speechtotext.component.css
+++ b/src/app/speechtotext/speechtotext.component.css
@@ -218,6 +218,7 @@
   -webkit-animation: typing 2s steps(21,end), blink-caret .5s step-end infinite alternate;
   overflow: hidden;
   animation-delay: 3.5s;
+  animation-duration: 1s;
 }
 
 .s2fp-h .spcht, .s2fp .spcht {


### PR DESCRIPTION
Fixes issue #711 

Changes: 
- Removes flickering of text-animation in voice search UI.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

(Not applicable here)
Please review @nikhilrayaprolu @Marauderer97 