### PR TITLE
Addresses #699: Remove whitespace from smaller screen sizes

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -97,6 +97,9 @@
   #navcontainer, #side-menu {
     margin-top: 8px;
   }
+  .top-nav {
+    width: 101.2%;
+  }
 }
 @media screen and (max-width:639px) {
   .align-navsearch-btn {

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -400,6 +400,16 @@ div.autocorrect{
   }
 }
 
+@media screen and (max-width: 768px) {
+  #search-options-field {
+    width: 98.5%;
+    margin-top: -0.2%;
+  }
+  ul#search-options {
+    margin-left: 14.5%;
+  }
+}
+
 @media screen and (max-width:767px) {
   div.result {
     padding-right: 30px;
@@ -453,6 +463,9 @@ div.autocorrect{
   div.feed{
     margin-left: 4%;
     width: 98%;
+  }
+  ul#search-options {
+    margin-left: 5%;
   }
 }
 
@@ -512,6 +525,16 @@ div.autocorrect{
     top: 2%;
   }
 }
+
+@media screen and (max-width: 425px) {
+  #search-options-field {
+    width: 93.5%;
+  }
+  ul#search-options {
+    margin-left: 1%;
+  }
+}
+
 @media screen and (max-width:423px) {
   #pag-bar {
     padding-left: 0;
@@ -526,9 +549,22 @@ div.autocorrect{
     font-size: small;
   }
 }
+
+@media screen and (max-width: 397px) {
+  ul#search-options {
+    margin-left: 5%;
+  }
+}
+
 @media screen and (max-width:379px) {
   #search-options li {
     padding: 0 3vw 12px;
+  }
+}
+
+@media screen and (max-width: 375px) {
+  #search-options-field {
+    width: 92%;
   }
 }
 


### PR DESCRIPTION
Fixes issue #699 

Changes:
- The whitespace was being observed on mobile screen sizes.
- It was due to the width of menu-bar being greater than screen size in terms of width.
- The width of menu-bar has been fixed and made responsive according to different screen size width.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

(Not applicable here)

Please review @Marauderer97 @nikhilrayaprolu 