### PR TITLE
Addresses #729: Dropdown menu has sufficient space to right side

### DIFF
--- a/src/app/dropdown/dropdown.component.css
+++ b/src/app/dropdown/dropdown.component.css
@@ -131,6 +131,24 @@ hr {
     padding-top: 10px;
 }
 
+@media screen and (max-width: 2670px) {
+    .dropdown-menu-box {
+        margin-left: -80%;
+    }
+}
+
+@media screen and (min-width: 2560px) {
+    .dropdown-menu-box {
+        margin-left: -80%;
+    }
+}
+
+@media screen and (min-width: 802px) and (max-width: 828px) {
+    .dropdown-menu-box {
+        margin-left: -14%;
+    }
+}
+
 @media screen and (max-width: 768px) {
     .dropdown-menu-box {
         margin-left: 60%;
@@ -143,11 +161,14 @@ hr {
     position: absolute;
     background-color: white;
     border: 1px solid #cccccc;
-    right: -38px;
+    right: -18px;
     left: auto;
   }
   .nav > li > a{
     padding-left: 11px;
     padding-right: 28px;
+  }
+  .dropdown-menu-box {
+      margin-left: -210%;
   }
 }

--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -95,6 +95,7 @@
     width: 83vw;
   }
 }
+
 @media screen and (max-width: 573px){
   .align-search-btn{
     left: -5%;


### PR DESCRIPTION
Fixes issue #729 

Changes: 
- Given dropdown menu sufficient space to the right side.
- Now it won't be get collapsed with the scroll bar.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

![screenshot from 2017-08-12 10-48-10](https://user-images.githubusercontent.com/22245418/29238151-3fd49bbe-7f4c-11e7-8e4d-c6fc98b165bd.png)

Please review @nikhilrayaprolu @Marauderer97 