### PR TITLE
Fixes #730: Instant predictions settings shows correct results per page

### DIFF
--- a/src/app/searchsettings/searchsettings.component.html
+++ b/src/app/searchsettings/searchsettings.component.html
@@ -45,7 +45,7 @@
           <h4><strong>Susper Instant Predictions</strong></h4>
           <p>When should we show you results as you type?</p>
           <input name="options" [(ngModel)]="instantresults" disabled value="#" type="radio" id="op1"><label for="op1">Only when my computer is fast enough</label><br>
-          <input name="options" [(ngModel)]="instantresults" [value]="true" type="radio" id="op2"><label for="op2">Always show instant results</label><br>
+          <input name="options" [(ngModel)]="instantresults" [value]="true" type="radio" id="op2" (click)="defaultCount()"><label for="op2">Always show instant results</label><br>
           <input name="options" [(ngModel)]="instantresults" [value]="false" type="radio" id="op3"><label for="op3">Never show instant results</label><br>
         </div>
       <hr>

--- a/src/app/searchsettings/searchsettings.component.ts
+++ b/src/app/searchsettings/searchsettings.component.ts
@@ -49,8 +49,13 @@ export class SearchsettingsComponent implements OnInit {
     }
     this.router.navigate(['/']);
   }
+
   onCancel() {
     this.router.navigate(['/']);
+  }
+
+  defaultCount() {
+    this.resultCount = 10;
   }
 
 }


### PR DESCRIPTION
Fixes issue #730 

Changes: 
- Instant results now show correct results per page.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

(Not applicable here)

Please review @nikhilrayaprolu @Marauderer97 @mariobehling 