### PR TITLE
Addresses #729, changes color of analytics box, results feed font size

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -41,6 +41,7 @@ a {
   color: #808080;
   line-height: 1.4;
   word-wrap: break-word;
+  font-size: small;
   margin-top: -8px;
 }
 

--- a/src/app/statsbox/statsbox.component.ts
+++ b/src/app/statsbox/statsbox.component.ts
@@ -18,12 +18,12 @@ export class StatsboxComponent implements OnInit {
   searchresults$: Observable<any>;
   public lineChartColors: Array<any> = [
     { // grey
-      backgroundColor: 'rgba(26, 13, 171, 0.4)',
-      borderColor: '#1a0dab',
-      pointBackgroundColor: '#1a0dab',
-      pointBorderColor: '#1a0dab',
-      pointHoverBackgroundColor: '#1a0dab',
-      pointHoverBorderColor: '#1a0dab'
+      backgroundColor: 'rgba(66, 133, 244, 0.4)',
+      borderColor: '#4285f4',
+      pointBackgroundColor: '#4285f4',
+      pointBorderColor: '#4285f4',
+      pointHoverBackgroundColor: '#4285f4',
+      pointHoverBorderColor: '#4285f4'
     }];
   public lineChartData: any[] = [{ data: [0], label: 'Results Frequency' }];
   public lineChartLabels = [2015, 2016, 2017];


### PR DESCRIPTION
Addresses #729

Changes: changes color of analytics box, results feed font size

Demo Link: [https://marauderer97.github.io/susper.com](https://marauderer97.github.io/susper.com)


Regarding length of search results title and description
![image](https://user-images.githubusercontent.com/20185076/29240299-c2f99b38-7f7f-11e7-9b07-555851439b57.png)
Changed the size of result description to small 
Changed the color of the graph 
![image](https://user-images.githubusercontent.com/20185076/29240283-96802ae0-7f7f-11e7-8861-bdd16125398c.png)
@harshit98 @nikhilrayaprolu Please review
