### PR TITLE
Fixes #742 Infobox and Analytics box changed for chrome only

### DIFF
--- a/src/app/infobox/infobox.component.css
+++ b/src/app/infobox/infobox.component.css
@@ -41,11 +41,19 @@ a {
 }
 
 /** Screen Responsiveness **/
-@media screen and (max-width: 1280px) {
-  .card{
-    width: 366px;
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  @media screen and (max-width: 1300px) {
+    .card {
+      width: 366px;
+    }
   }
 }
+@media screen and (max-width: 1280px) {
+    .card {
+      width: 366px;
+    }
+}
+
 @media screen and (max-width: 1190px) {
   .card{
     width: 278px;

--- a/src/app/statsbox/statsbox.component.css
+++ b/src/app/statsbox/statsbox.component.css
@@ -5,7 +5,7 @@
   margin-bottom: 16px;
   padding: 22px 22px 18px 22px;
   transition: 0.3s;
-  width: 434px;
+  width: 454px;
   margin-top: 10px;
 
 }
@@ -50,11 +50,20 @@ a {
   font-family: Arial, sans-serif;
 }
 
+/** Screen Responsiveness **/
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  @media screen and (max-width: 1300px) {
+    .card {
+      width: 366px;
+    }
+  }
+}
 @media screen and (max-width: 1280px) {
-  .card{
+  .card {
     width: 366px;
   }
 }
+
 @media screen and (max-width: 1190px) {
   .card{
     width: 278px;


### PR DESCRIPTION
Fixes issue #742
Changes: Infobox and Analytics box changed for chrome only
I have replicated what Google does. 
Google in Firefox at 1290px
![image](https://user-images.githubusercontent.com/20185076/29249392-453a6ae2-804c-11e7-87d4-42e65e4c823c.png)
Susper in Firefox at 1290px
![image](https://user-images.githubusercontent.com/20185076/29249394-59272aea-804c-11e7-9872-c6bf3341e01e.png)
Google in Chrome at 1290px
![image](https://user-images.githubusercontent.com/20185076/29249395-6d68411a-804c-11e7-9078-dbf792f537b6.png)
Susper in Chrome at 1290px
![image](https://user-images.githubusercontent.com/20185076/29249397-812b00e8-804c-11e7-9848-d06575848e28.png)

NOTE: Also applied the exact same CSS for the Analytics Box

Demo Link: [https://marauderer97.github.io/susper.com/](https://marauderer97.github.io/susper.com/)

