### PR TITLE
Fixes #740 Customization shifted from Tools drop-down to settings

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -12,6 +12,7 @@
         </a>
         <ul class="dropdown-menu" aria-labelledby="settings" id="setting-dropdown">
           <li routerLink="/preferences">Search settings</li>
+          <li data-toggle="modal" data-target="#customization">Customization</li>
         </ul>
       </li>
       <li class="dropdown">
@@ -22,7 +23,6 @@
           <li (click)="filterByContext()">Context Ranking</li>
           <li (click)="filterByDate()">Sort by Date</li>
           <li data-toggle="modal" data-target="#myModal">Advanced Search</li>
-          <li data-toggle="modal" data-target="#customization">Customization</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
Fixes issue #740 
Changes: Customization shifted from Tools drop-down to settings

Demo Link: [https://marauderer97.github.io/susper.com/](https://marauderer97.github.io/susper.com/)

Screenshots for the change: 

![image](https://user-images.githubusercontent.com/20185076/29249494-268d030a-804e-11e7-8168-352b9b994eaf.png)
![image](https://user-images.githubusercontent.com/20185076/29249499-33b8783e-804e-11e7-93f2-445c319ee604.png)
