### PR TITLE
Fixes #749: Pagination bar changed for small devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/animations": "^4.3.6",
+    "@angular/cdk": "^2.0.0-beta.8",
     "@angular/cli": "^1.0.2",
     "@angular/common": "4.1.3",
     "@angular/compiler": "4.1.3",
@@ -21,6 +23,7 @@
     "@angular/core": "4.1.3",
     "@angular/forms": "4.1.3",
     "@angular/http": "4.1.3",
+    "@angular/material": "^2.0.0-beta.8",
     "@angular/platform-browser": "4.1.3",
     "@angular/platform-browser-dynamic": "4.1.3",
     "@angular/router": "4.1.3",

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -367,6 +367,12 @@ div.autocorrect{
 }
  /*Responsiveness*/
 
+@media screen and (min-width: 426px) and (max-width: 2560px) {
+  .next-page-mobile {
+    display: none;
+  }
+}
+
 @media screen and (min-width:1920px) {
   div.autocorrect{
     margin-left: 191px;
@@ -509,28 +515,78 @@ div.autocorrect{
     top: 2%;
   }
 }
-@media screen and (max-width:423px) {
+@media screen and (max-width:425px) {
   #pag-bar {
     padding-left: 0;
   }
   .page-text {
     font-size: x-large;
+    display: none;
   }
   .page-item span{
     font-size: 10px;
   }
   .arrow {
-    font-size: small;
+    font-size: 25px;
+    color: #c8c4c3;
+  }
+  .page-number {
+    display: none;
+  }
+  #pag-bar {
+    margin-bottom: -13%;
+    margin-left: 12%;
+  }
+  .card {
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+    margin-bottom: 16px;
+    padding: 0px 46px 12px 22px;
+    width: 380px;
+    height: 50px;
+    margin-left: 8%;
+    margin-top: 2%;
+    background-color: #ffffff;
+  }
+  .side-text {
+    display: none;
+  }
+  .page-item2 span {
+    background-color: #ffffff;
+    margin-top: -13%;
+  }
+  .spl {
+    margin-left: 60%;
+  }
+  div.next-page-mobile {
+    margin-left: 32%;
+    margin-top: 6%;
+    font-size: 16px;
+    font-family: Helvetica;
+  }
+  #left-arrow {
+    margin-top: 1.1%;
   }
 }
 @media screen and (max-width:379px) {
   #search-options li {
     padding: 0 3vw 12px;
   }
+  .card {
+    margin-left: 4%;
+  }
+  .side-text {
+    margin-left: -50%;
+  }
 }
 
 @media screen and (max-width:330px) {
   #search-options li {
     padding: 0 2vw 12px;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  .side-text {
+    margin-left: -50%;
   }
 }

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -134,25 +134,45 @@
     </div>
     <br>
     <div class="clean"></div>
+    <div class="card">
     <div class="pagination-bar" *ngIf="!Display('images')">
       <div class="pagination-property" *ngIf="noOfPages>1">
         <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
           <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
             <ul class="pagination" id="pag-bar">
-              <li class="page-item2" *ngIf="!getStyle(1)"><span class="spl" (click)="decPresentPage()"><div class="arrow">< </div><div class="side-text">Previous</div></span></li>
-              <li class="page-item"><span class="page-link" href="#" (click)="decPresentPage()"><div class="page-text prev">S</div><br/></span></li>
-              <li class="page-item" *ngFor="let num of getNumber(maxPage)"><span class="page-link" *ngIf="presentPage>=4 && presentPage-3+num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
+              <li class="page-item2" *ngIf="!getStyle(1)">
+                <span class="spl" id="left-arrow" (click)="decPresentPage()">
+                  <div class="arrow" (click)="decreasePage()"><</div>
+                  <div class="side-text">Previous</div>
+                </span>
+              </li>
+              <li class="page-item">
+                <span class="page-link" href="#" (click)="decPresentPage()">
+                  <div class="page-text prev">S</div>
+                  <br/>
+                </span>
+              </li>
+              <li class="page-item" *ngFor="let num of getNumber(maxPage)">
+                <span class="page-link" *ngIf="presentPage>=4 && presentPage-3+num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
                                                                                  (click)="getPresentPage(presentPage-3+num)" href="#"><div [class.active_page]="getStyle(presentPage-3+num)" class="page-text">U</div><span class="page-number">{{presentPage-3+num}}</span></span>
                 <span class="page-link" *ngIf="presentPage<4 && num<=noOfPages" [class.active_page]="num+1 == presentPage" (click)="getPresentPage(num+1)"
                       href="#"><div [class.active_page]="num+1 == presentPage" class="page-text">U</div><span class="page-number">{{num+1}}</span></span>
               </li>
-              <li class="page-item"><span class="page-link" (click)="incPresentPage()"><div class="page-text next">SPER</div></span></li>
-              <li class="page-item2" *ngIf="!getStyle(maxPage)"><span class="spl" (click)="incPresentPage()"><div class="arrow">></div><div class="side-text">Next</div></span></li>
-
+              <li class="page-item">
+                <span class="page-link" (click)="incPresentPage()"><div class="page-text next">SPER</div></span>
+              </li>
+              <div class="next-page-mobile">Page {{count}}</div>
+              <li class="page-item2" *ngIf="!getStyle(maxPage)">
+                <span class="spl" (click)="incPresentPage()">
+                  <div class="arrow" (click)="increasePage()">></div>
+                  <div class="side-text">Next</div>
+                </span>
+              </li>
             </ul>
           </div>
         </nav>
       </div>
+    </div>
     </div>
     <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
       <app-advancedsearch></app-advancedsearch>

--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -26,6 +26,7 @@ export class ResultsComponent implements OnInit {
   begin: number;
   message: string;
   query: any;
+  count: number = 1;
   searchdata: any = {
     query: '',
     start: 0,
@@ -234,6 +235,15 @@ export class ResultsComponent implements OnInit {
     this.store.dispatch(new queryactions.QueryServerAction(urldata));
 
   };
+
+  increasePage() {
+    this.count += 1;
+  }
+
+  decreasePage() {
+    this.count -= 1;
+  }
+
   ngOnInit() {
   }
 }


### PR DESCRIPTION
Fixes issue #749

Changes: 
- Pagination bar changed for smaller devices similar to market leader.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

![screenshot from 2017-08-18 00-27-31](https://user-images.githubusercontent.com/22245418/29429438-50629e16-83ae-11e7-9a7b-31f62c416527.png)
![screenshot from 2017-08-18 00-28-01](https://user-images.githubusercontent.com/22245418/29429448-56671eb8-83ae-11e7-8117-61715a7ce525.png)

Please review @nikhilrayaprolu @Marauderer97 
There are some conflicts while deploying it. @nikhilrayaprolu kindly deploy this PR on heroku.