### PR TITLE
Fixes #765, scroll feature errors fixed

### DIFF
--- a/src/app/results/results.component.ts
+++ b/src/app/results/results.component.ts
@@ -99,7 +99,10 @@ export class ResultsComponent implements OnInit {
     let urldata = Object.assign({}, this.searchdata);
     this.getPresentPage(1);
     this.resultDisplay = 'videos';
+    urldata.start = 0;
     urldata.rows = 100;
+    urldata.nopagechange = false;
+    urldata.append = false;
     urldata.fq = 'url_file_ext_s:(avi+OR+mov+OR+flw+OR+mp4)';
     urldata.resultDisplay = this.resultDisplay;
     this.store.dispatch(new queryactions.QueryServerAction(urldata));
@@ -121,6 +124,8 @@ export class ResultsComponent implements OnInit {
     this.resultDisplay = 'all';
     delete urldata.fq;
     urldata.rows = 10;
+    urldata.nopagechange = false;
+    urldata.append = false;
     urldata.resultDisplay = this.resultDisplay;
     this.store.dispatch(new queryactions.QueryServerAction(urldata));
   }
@@ -238,7 +243,6 @@ export class ResultsComponent implements OnInit {
     urldata.append = true;
     urldata.nopagechange = true;
     this.store.dispatch(new queryactions.QueryServerAction(urldata));
-
   };
 
   increasePage() {


### PR DESCRIPTION
Fixes issue #765 

Changes: Scroll feature errors are fixed. Every tab displays its own results.

Demo Link: [https://marauderer97.github.io/susper.com](https://marauderer97.github.io/susper.com)

Screenshots for the change: 
Before:
![image](https://user-images.githubusercontent.com/20185076/29996865-521dd0d6-9024-11e7-8a5f-09e32446b94e.png)
After:
![image](https://user-images.githubusercontent.com/20185076/29996898-c384c478-9024-11e7-97ad-ef8b2a2b29c2.png)
Before:
![image](https://user-images.githubusercontent.com/20185076/29996885-95a670c4-9024-11e7-9948-3679b90d21f0.png)
After:
![image](https://user-images.githubusercontent.com/20185076/29996878-8a231018-9024-11e7-9d0c-5c53e72edcde.png)

