### PR TITLE
Fixes positioning of no results text in image search

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -346,7 +346,7 @@ a {
 }
 
 .noResults {
-  margin-left: 3%;
+  margin-left: 172px;
   margin-top: 7%;
   font-size: medium;
   font-weight: normal;
@@ -373,6 +373,7 @@ div.autocorrect {
   margin-left: 172px;
 }
 
+
  /*Responsiveness*/
 @media screen and (min-width: 426px) and (max-width: 2560px) {
   .next-page-mobile {
@@ -382,6 +383,10 @@ div.autocorrect {
 
 @media screen and (min-width:1920px) {
   div.autocorrect {
+    margin-left: 191px;
+  }
+
+  div.noResults {
     margin-left: 191px;
   }
 
@@ -405,6 +410,10 @@ div.autocorrect {
 
 @media screen and (max-width:1079px) {
   div.autocorrect {
+    margin-left: 134px;
+  }
+
+  div.noResults {
     margin-left: 134px;
   }
 
@@ -481,6 +490,11 @@ div.autocorrect {
   }
 
   div.autocorrect {
+    margin-left: 4%;
+    padding-left: 0;
+  }
+
+  div.noResults {
     margin-left: 4%;
     padding-left: 0;
   }

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -110,9 +110,7 @@ a {
 }
 
 .container-fluid li {
-  height: 15px;
-  line-height: 15px;
-  padding-top: 28px;
+  line-height: 18px;
 }
 
 .container-fluid li a {
@@ -363,10 +361,7 @@ a {
   padding-left: 16px;
 }
 
-.noResults >ul> li {
-  padding-top: 0;
-  padding-bottom: 18px;
-}
+
 
 .noResults em {
   font-weight: bold;

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -38,6 +38,7 @@
         <app-auto-correct [hidden]="hideAutoCorrect"></app-auto-correct>
       </div>
     </div>
+
   <div class="container-fluid text-result" *ngIf="Display('all')">
     <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
 
@@ -83,8 +84,8 @@
 
     <!-- Image section -->
     <div *ngIf="Display('images')">
-      <div class="container">
-        <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+      
+        <div *ngIf="totalNumber < 1" class="container-fluid">
           <div class="noResults">
             <p>Your search - <em>{{searchdata.query}}</em> - did not match any images.</p>
             <p>Suggestions:</p>
@@ -95,6 +96,8 @@
             </ul>
           </div>
         </div>
+
+      <div class="container">
           <div class="search-results"
                infiniteScroll
                [infiniteScrollDistance]="2"

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -84,7 +84,7 @@
     <!-- Image section -->
     <div *ngIf="Display('images')">
       <div class="container">
-        <div *ngIf="totalNumber < 1">
+        <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
           <div class="noResults">
             <p>Your search - <em>{{searchdata.query}}</em> - did not match any images.</p>
             <p>Suggestions:</p>


### PR DESCRIPTION
Fixes issue #634 

Changes: Positioning of no results text changed for image search such that it matches that of basic results and video results. Also fixed line height issue for the text in mobile screens.

Screenshots for the change: 
Before
![image](https://user-images.githubusercontent.com/20743219/31121468-e5acee88-a855-11e7-9873-200d858dd7bd.png)

After
![image](https://user-images.githubusercontent.com/20743219/31121479-f3b28e7a-a855-11e7-811a-ea6dc940deae.png)
![image](https://user-images.githubusercontent.com/20743219/31121536-38616abe-a856-11e7-9f69-2e5e6368176f.png)
