### PR TITLE
Fixes #722: Typing on start page search box moves search bar upwards

### DIFF
--- a/src/app/searchsettings/searchsettings.component.html
+++ b/src/app/searchsettings/searchsettings.component.html
@@ -52,8 +52,8 @@
           <h4><strong>Susper Instant Predictions</strong></h4>
           <p>When should we show you results as you type?</p>
           <input name="options" [(ngModel)]="instantresults" disabled value="#" type="radio" id="op1"><label for="op1">Only when my computer is fast enough</label><br>
-          <input name="options" [(ngModel)]="instantresults" [value]="true" type="radio" id="op2" (click)="defaultCount()"><label for="op2">Always show instant results</label><br>
-          <input name="options" [(ngModel)]="instantresults" [value]="false" type="radio" id="op3"><label for="op3">Never show instant results</label><br>
+          <input name="options" [(ngModel)]="instantresults" [value]="false" type="radio" id="op2" (click)="defaultCount()"><label for="op2">Always show instant results</label><br>
+          <input name="options" [(ngModel)]="instantresults" [value]="true" type="radio" id="op3"><label for="op3">Never show instant results</label><br>
         </div>
 
         <hr>

--- a/src/app/searchsettings/searchsettings.component.ts
+++ b/src/app/searchsettings/searchsettings.component.ts
@@ -24,6 +24,7 @@ export class SearchsettingsComponent implements OnInit {
       this.instantresults = JSON.parse(localStorage.getItem('instantsearch')).value || false;
     } else {
       this.instantresults = false;
+      localStorage.setItem('instantsearch', JSON.stringify({value: true}));
     }
 
     if (localStorage.getItem('resultscount')) {


### PR DESCRIPTION
Fixes issue #722 

Changes:
- Instant result feature has been set to default.

Demo Link: https://harshit98.github.io/susper.com/

Screenshots for the change: 

(Not applicable here)

@mariobehling @nikhilrayaprolu @Marauderer97 Please review. 