### PR TITLE
Fixes #789 : Hiding card in case of no search results

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -141,7 +141,7 @@
     </div>
     <br>
     <div class="clean"></div>
-    <div class="card">
+    <div class="card" *ngIf="totalNumber > 0">
     <div class="pagination-bar" *ngIf="!Display('images')">
       <div class="pagination-property" *ngIf="noOfPages>1">
         <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">


### PR DESCRIPTION
Fixes issue #789 

Changes: 
Hide the pagination card when there are no search results.

Demo Link:  [Susper.com](https://susperdeploy.firebaseapp.com/)

Screenshots for the change: 

Before
![screenshot_2017-10-12-12-15-15-875_com android chrome](https://user-images.githubusercontent.com/13784830/31482811-61b7a46c-af47-11e7-92f9-f7e00bdbdf5c.png)

After
![screenshot_2017-10-12-12-14-49-830_com android chrome](https://user-images.githubusercontent.com/13784830/31482815-650879fc-af47-11e7-823b-61f30611ab0b.png)