### PR TITLE
Fixes #634 : Empty Spaces around no results text

### DIFF
--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -347,7 +347,7 @@ a {
 
 .noResults {
   margin-left: 172px;
-  margin-top: 7%;
+  margin-top: 2%;
   font-size: medium;
   font-weight: normal;
 }

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -1,93 +1,97 @@
 <div class="resultContainer">
-<app-navbar></app-navbar>
-<div class="row" [style.background-color]="themeService.backgroundColor">
-  <div class="container-fluid" id="search-options-field">
-    <ul type="none" id="search-options">
-      <li [class.active_view]="Display('all')" (click)="docClick()">All</li>
-      <li [class.active_view]="Display('images')" (click)="imageClick()">Images</li>
-      <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
-      <li class="dropdown">
-        <a href="#" id="settings" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-          Settings
-        </a>
-        <ul class="dropdown-menu" aria-labelledby="settings" id="setting-dropdown">
-          <li routerLink="/preferences">Search settings</li>
-          <li data-toggle="modal" data-target="#customization">Customization</li>
-        </ul>
-      </li>
-      <li class="dropdown">
-        <a href="#" id="tools" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-          Tools
-        </a>
-        <ul class="dropdown-menu" aria-labelledby="tools" id="tool-dropdown">
-          <li (click)="filterByContext()">Context Ranking</li>
-          <li (click)="filterByDate()">Sort by Date</li>
-          <li data-toggle="modal" data-target="#myModal">Advanced Search</li>
-        </ul>
-      </li>
-    </ul>
-  </div>
-
-  <div [hidden]="hidefooter">
-    <!-- Basic results 'All' -->
-    <div class="container-fluid">
-      <div class="result message-bar" *ngIf="totalNumber > 0 && !Display('images')">
-        {{message}}
-      </div>
-      <div class="autocorrect">
-        <app-auto-correct [hidden]="hideAutoCorrect"></app-auto-correct>
-      </div>
-    </div>
-
-  <div class="container-fluid text-result" *ngIf="Display('all')">
-    <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
-
-      <div class="noResults">
-      <p>Your search - <em>{{searchdata.query}}</em> - did not match any documents.</p>
-      <p>Suggestions:</p>
-      <ul>
-        <li>Make sure that all words are spelled correctly.</li>
-        <li>Try different keywords.</li>
-        <li>Try more general keywords.</li>
+  <app-navbar></app-navbar>
+  <div class="row" [style.background-color]="themeService.backgroundColor">
+    <div class="container-fluid" id="search-options-field">
+      <ul type="none" id="search-options">
+        <li [class.active_view]="Display('all')" (click)="docClick()">All</li>
+        <li [class.active_view]="Display('images')" (click)="imageClick()">Images</li>
+        <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
+        <li class="dropdown">
+          <a href="#" id="settings" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            Settings
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="settings" id="setting-dropdown">
+            <li routerLink="/preferences">Search settings</li>
+            <li data-toggle="modal" data-target="#customization">Customization</li>
+          </ul>
+        </li>
+        <li class="dropdown">
+          <a href="#" id="tools" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            Tools
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="tools" id="tool-dropdown">
+            <li (click)="filterByContext()">Context Ranking</li>
+            <li (click)="filterByDate()">Sort by Date</li>
+            <li data-toggle="modal" data-target="#myModal">Advanced Search</li>
+          </ul>
+        </li>
       </ul>
-      </div>
     </div>
-    <div class="combo-box">
-      <app-infobox></app-infobox>
-      <button class="btn" id="toggle-button" (click)="BoxToggle()" type="button" data-toggle="collapse" data-target="#statbox" aria-expanded="false" aria-controls="collapseExample">
-        {{boxMessage}} Analytics
-      </button>
-      <app-statsbox class="collapse" id="statbox"></app-statsbox>
-    </div>
-      <div class="feed">
-        <app-intelligence [hidden]="hideAutoCorrect || hideIntelligence"></app-intelligence>
-        <div class="result">
-        <div *ngFor="let item of items$|async" class="result">
-          <div class="title">
-            <a class="title-pointer" href="{{item.link}}" [style.color]="themeService.titleColor">{{item.title}}</a>
-          </div>
-          <div class="link">
-            <p [style.color]="themeService.linkColor">{{item.link}}</p>
-          </div>
-          <div class="description">
-            <p [style.color]="themeService.descriptionColor">{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
-          </div>
+
+    <div [hidden]="hidefooter">
+      <!-- Basic results 'All' -->
+      <div class="container-fluid">
+        <div class="result message-bar" *ngIf="totalNumber > 0 && !Display('images')">
+          {{message}}
+        </div>
+        <div class="autocorrect">
+          <app-auto-correct [hidden]="hideAutoCorrect"></app-auto-correct>
         </div>
       </div>
-        <app-related-search [hidden]="hidefooter"></app-related-search>
-      </div>
-    <div class="infobox">
-      <app-infobox [hidden]="hidefooter || hideAutoCorrect || totalNumber < 1" *ngIf="Display('all')"></app-infobox>
-      <app-statsbox [hidden]="hidefooter || hideAutoCorrect || totalNumber < 1" *ngIf="Display('all')"></app-statsbox>
-    </div>
-  </div>
 
-    <!-- Image section -->
-    <div *ngIf="Display('images')">
-      
+      <div class="text-result" *ngIf="Display('all')">
         <div *ngIf="totalNumber < 1" class="container-fluid">
           <div class="noResults">
-            <p>Your search - <em>{{searchdata.query}}</em> - did not match any images.</p>
+            <p>Your search -
+              <em>{{searchdata.query}}</em> - did not match any documents.</p>
+            <p>Suggestions:</p>
+            <ul>
+              <li>Make sure that all words are spelled correctly.</li>
+              <li>Try different keywords.</li>
+              <li>Try more general keywords.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="container-fluid">
+          <div class="combo-box">
+            <app-infobox></app-infobox>
+            <button class="btn" id="toggle-button" (click)="BoxToggle()" type="button" data-toggle="collapse" data-target="#statbox"
+              aria-expanded="false" aria-controls="collapseExample" *ngIf="totalNumber > 0">
+              {{boxMessage}} Analytics
+            </button>
+            <app-statsbox class="collapse" id="statbox"></app-statsbox>
+          </div>
+          <div class="feed">
+            <app-intelligence [hidden]="hideAutoCorrect || hideIntelligence"></app-intelligence>
+            <div class="result">
+              <div *ngFor="let item of items$|async" class="result">
+                <div class="title">
+                  <a class="title-pointer" href="{{item.link}}" [style.color]="themeService.titleColor">{{item.title}}</a>
+                </div>
+                <div class="link">
+                  <p [style.color]="themeService.linkColor">{{item.link}}</p>
+                </div>
+                <div class="description">
+                  <p [style.color]="themeService.descriptionColor">{{item.pubDate|date:'MMMM d, yyyy'}} - {{item.description}}</p>
+                </div>
+              </div>
+            </div>
+            <app-related-search [hidden]="hidefooter"></app-related-search>
+          </div>
+          <div class="infobox">
+            <app-infobox [hidden]="hidefooter || hideAutoCorrect || totalNumber < 1" *ngIf="Display('all')"></app-infobox>
+            <app-statsbox [hidden]="hidefooter || hideAutoCorrect || totalNumber < 1" *ngIf="Display('all')"></app-statsbox>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Image section -->
+      <div *ngIf="Display('images')">
+        <div *ngIf="totalNumber < 1" class="container-fluid">
+          <div class="noResults">
+            <p>Your search -
+              <em>{{searchdata.query}}</em> - did not match any images.</p>
             <p>Suggestions:</p>
             <ul>
               <li>Make sure that all words are spelled correctly.</li>
@@ -97,102 +101,109 @@
           </div>
         </div>
 
-      <div class="container">
-          <div class="search-results"
-               infiniteScroll
-               [infiniteScrollDistance]="2"
-               [infiniteScrollThrottle]="300"
-               (scrolled)="onScroll()">
+        <div class="container">
+          <div class="search-results" infiniteScroll [infiniteScrollDistance]="2" [infiniteScrollThrottle]="300" (scrolled)="onScroll()">
           </div>
-        <div *ngIf="totalNumber > 0">
-          <div *ngFor="let item of items;let i = index">
-            <div class="item">
-              <img src="{{item.link}}" height="200px" (click)="expandImage(i)" [ngClass]="'image'+i">
-            </div>
-            <div class=" item image-viewer" *ngIf="expand && expandedrow === i">
-              <span class="helper"></span> <img [src]="items[expandedkey].link" height="200px" style="vertical-align: middle;">
+          <div *ngIf="totalNumber > 0">
+            <div *ngFor="let item of items;let i = index">
+              <div class="item">
+                <img src="{{item.link}}" height="200px" (click)="expandImage(i)" [ngClass]="'image'+i">
+              </div>
+              <div class=" item image-viewer" *ngIf="expand && expandedrow === i">
+                <span class="helper"></span>
+                <img [src]="items[expandedkey].link" height="200px" style="vertical-align: middle;">
+              </div>
+
             </div>
 
           </div>
-
         </div>
       </div>
-    </div>
-    <!-- END -->
-    <div class="video-result" *ngIf="Display('videos')">
-      <div *ngIf="totalNumber < 1" class="container-fluid col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
-        <div class="noResults">
-          <p>Your search - <em>{{searchdata.query}}</em> - did not match any videos.</p>
-          <p>Suggestions:</p>
-          <ul>
-            <li>Make sure that all words are spelled correctly.</li>
-            <li>Try different keywords.</li>
-            <li>Try more general keywords.</li>
-          </ul>
-        </div>
-      </div>
-      <div class="feed container">
-      <div *ngFor="let item of items$|async" class="result">
-        <div class="title">
-          <a class="title-pointer" href="{{item.path}}">{{item.title}}</a>
-        </div>
-        <div class="link">
-          <p>{{item.link}}</p>
-        </div>
-      </div>
-    </div>
-    </div>
-    <br>
-    <div class="clean"></div>
-    <div class="card" *ngIf="totalNumber > 0">
-    <div class="pagination-bar" *ngIf="!Display('images')">
-      <div class="pagination-property" *ngIf="noOfPages>1">
-        <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
-          <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
-            <ul class="pagination" id="pag-bar">
-              <li class="page-item2" *ngIf="!getStyle(1)">
-                <span class="spl" id="left-arrow" (click)="decPresentPage()">
-                  <div class="arrow" (click)="decreasePage()"><</div>
-                  <div class="side-text">Previous</div>
-                </span>
-              </li>
-              <li class="page-item">
-                <span class="page-link" href="#" (click)="decPresentPage()">
-                  <div class="page-text prev">S</div>
-                  <br/>
-                </span>
-              </li>
-              <li class="page-item" *ngFor="let num of getNumber(maxPage)">
-                <span class="page-link" *ngIf="presentPage>=4 && presentPage-3+num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
-                                                                                 (click)="getPresentPage(presentPage-3+num)" href="#"><div [class.active_page]="getStyle(presentPage-3+num)" class="page-text">U</div><span class="page-number">{{presentPage-3+num}}</span></span>
-                <span class="page-link" *ngIf="presentPage<4 && num<=noOfPages" [class.active_page]="num+1 == presentPage" (click)="getPresentPage(num+1)"
-                      href="#"><div [class.active_page]="num+1 == presentPage" class="page-text">U</div><span class="page-number">{{num+1}}</span></span>
-              </li>
-              <li class="page-item">
-                <span class="page-link" (click)="incPresentPage()"><div class="page-text next">SPER</div></span>
-              </li>
-              <div class="next-page-mobile">Page {{count}}</div>
-              <li class="page-item2" *ngIf="!getStyle(maxPage)">
-                <span class="spl" (click)="incPresentPage()">
-                  <div class="arrow" (click)="increasePage()">></div>
-                  <div class="side-text">Next</div>
-                </span>
-              </li>
+      <!-- END -->
+      <div class="video-result" *ngIf="Display('videos')">
+        <div *ngIf="totalNumber < 1" class="container-fluid">
+          <div class="noResults">
+            <p>Your search -
+              <em>{{searchdata.query}}</em> - did not match any videos.</p>
+            <p>Suggestions:</p>
+            <ul>
+              <li>Make sure that all words are spelled correctly.</li>
+              <li>Try different keywords.</li>
+              <li>Try more general keywords.</li>
             </ul>
           </div>
-        </nav>
+        </div>
+        <div class="feed container">
+          <div *ngFor="let item of items$|async" class="result">
+            <div class="title">
+              <a class="title-pointer" href="{{item.path}}">{{item.title}}</a>
+            </div>
+            <div class="link">
+              <p>{{item.link}}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <br>
+      <div class="clean"></div>
+      <div class="card" *ngIf="totalNumber > 0">
+        <div class="pagination-bar" *ngIf="!Display('images')">
+          <div class="pagination-property" *ngIf="noOfPages>1">
+            <nav aria-label="Page navigation" *ngIf="(items$ | async)?.length!=0">
+              <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-lg-10 col-lg-offset-1">
+                <ul class="pagination" id="pag-bar">
+                  <li class="page-item2" *ngIf="!getStyle(1)">
+                    <span class="spl" id="left-arrow" (click)="decPresentPage()">
+                      <div class="arrow" (click)="decreasePage()">
+                        <</div>
+                          <div class="side-text">Previous</div>
+                    </span>
+                  </li>
+                  <li class="page-item">
+                    <span class="page-link" href="#" (click)="decPresentPage()">
+                      <div class="page-text prev">S</div>
+                      <br/>
+                    </span>
+                  </li>
+                  <li class="page-item" *ngFor="let num of getNumber(maxPage)">
+                    <span class="page-link" *ngIf="presentPage>=4 && presentPage-3+num<=noOfPages" [class.active_page]="getStyle(presentPage-3+num)"
+                      (click)="getPresentPage(presentPage-3+num)" href="#">
+                      <div [class.active_page]="getStyle(presentPage-3+num)" class="page-text">U</div>
+                      <span class="page-number">{{presentPage-3+num}}</span>
+                    </span>
+                    <span class="page-link" *ngIf="presentPage<4 && num<=noOfPages" [class.active_page]="num+1 == presentPage" (click)="getPresentPage(num+1)"
+                      href="#">
+                      <div [class.active_page]="num+1 == presentPage" class="page-text">U</div>
+                      <span class="page-number">{{num+1}}</span>
+                    </span>
+                  </li>
+                  <li class="page-item">
+                    <span class="page-link" (click)="incPresentPage()">
+                      <div class="page-text next">SPER</div>
+                    </span>
+                  </li>
+                  <div class="next-page-mobile">Page {{count}}</div>
+                  <li class="page-item2" *ngIf="!getStyle(maxPage)">
+                    <span class="spl" (click)="incPresentPage()">
+                      <div class="arrow" (click)="increasePage()">></div>
+                      <div class="side-text">Next</div>
+                    </span>
+                  </li>
+                </ul>
+                </div>
+            </nav>
+            </div>
+          </div>
+        </div>
+        <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+          <app-advancedsearch></app-advancedsearch>
+        </div>
+        <div class="modal fade" id="customization" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+          <app-theme></app-theme>
+        </div>
+
+        <!--footer navigation bar goes here-->
       </div>
     </div>
-    </div>
-    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-      <app-advancedsearch></app-advancedsearch>
-    </div>
-    <div class="modal fade" id="customization" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-      <app-theme></app-theme>
-    </div>
-
-    <!--footer navigation bar goes here-->
+    <app-footer-navbar [hidden]="hidefooter"></app-footer-navbar>
   </div>
-</div>
-<app-footer-navbar [hidden]="hidefooter"></app-footer-navbar>
-</div>


### PR DESCRIPTION
Fixes issue #634 

Changes: 
-  Removed empty spaces between autocorrect and no results text
-  Removed irrelevant margin-left of no results text in all tab and video tab.
-  Hide analytics box when no results are shown. 
-  Formatted code for better readability.

Demo Link: [Susper.com](https://susperdeploy.firebaseapp.com)

Screenshots for the change: 

Before
![1](https://user-images.githubusercontent.com/13784830/31865206-6e7d8c40-b788-11e7-9b7d-43be6cc39597.PNG)

After
![2](https://user-images.githubusercontent.com/13784830/31865207-6ec0fc82-b788-11e7-9482-77f995fcbeca.PNG)

Before
![3](https://user-images.githubusercontent.com/13784830/31865208-6f03c7f6-b788-11e7-9deb-3fa56829a6b5.PNG)

After
![4](https://user-images.githubusercontent.com/13784830/31865209-6f48a0e2-b788-11e7-9602-9b3d267d3199.PNG)

@harshit98 @nikhilrayaprolu Please review this PR.