### PR TITLE
Fixes #776 : Firefox Search Engine Installation

### DIFF
--- a/susper.xml
+++ b/susper.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OpenSearchDescription xmlns="https://a9.com/-/spec/opensearch/1.1/" xmlns:moz="https://www.mozilla.org/2006/browser/search/">
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>susper</ShortName>
   <LongName>susper.com the open search provider</LongName>
-  <Image type="image/gif">https://search.yacy.net/env/grafics/yacy.png</Image>
   <Image type="image/png" width="16" height="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAICAYAAADwdn+XAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAH4SURBVCiRLcxPSJNxHMfxz/d59uzRbepYLLfxIDJ1BF075vAkBB66iLD+CWvWTA9RCHayP2tOwz/JUua0ooPBlKKL1WUespDYISPLpAInRgSarGzPsz2/bwd7n1+8KT4x2SJLFAZzQamQv47dXNkRgiINDVrz0tJAWdPCPURSNJ+fPqpp58NEGCBCjRB4C3C/RSI623fp4hkAYN5QR66vdDPDXyhsEw5yAdzo83XVEYlbAM0B/IkILQCCEhGU/xBETboQzACbudxnPpgKUwiYul6wCcF2Xdczm5vpVD6fDjFjVjIFzwwlpx7F7yZbAaCqyi7bHBXSi+VxFzPbA0fqqr0+p/T8zaDhb/S8q/d7Xh0PXnvfcXqkJ59Pq1J/b3Sps/1C1H3YHXg4Pz/cFPDUOJ12clU5HQBUi1WSAcKxprqfD+aunNK0Q73CFL++rG+PtrXFIhIz2ysrf9vCHe1ThmEwSPwp7hvWbHZVJqKdvZ19t2GU9goFWBOxjHch0zfzenmw2RSc/f5jN0h37qVOXO3uWgSAsen76W8bf4cXn35YlWX5paLQx2KxdNlqVUdrax1PtrZ2FxRFfkaEfcMod6qqZdZimmU1MTGZAoFKpdLj8aHu9fr6SCszx4noJBElQqGWG7ncmsUwyreLReMcwNWAlPR63bF/RSveCbyuLsgAAAAASUVORK5CYII=</Image>
   <Language>en-us</Language>
   <OutputEncoding>UTF-8</OutputEncoding>
   <InputEncoding>UTF-8</InputEncoding>
   <AdultContent>false</AdultContent>
   <Description>susper open search provider</Description>
-  <Url type="text/html" template="https://susper.com/search?query={searchTerms}"/>
   <Url type="text/html" method="GET" template="https://susper.com/search?query={searchTerms}"/>
   <!-- syntax according to http://www.loc.gov/standards/sru/. Set verify=true to get snippets in the search results -->
   <Developer>See https://github.com/fossasia/susper.com</Developer>


### PR DESCRIPTION
Fixes issue #776

Changes: 
Modified to match Firefox's OpenSearch schema
Removed Broken Link

Demo Link:  [Susper](https://susperdeploy.firebaseapp.com)

Screenshots for the change: (Not Applicable)