### PR TITLE
Fixes issue #769 Design Standards of Crawl Job Page

### DIFF
--- a/src/app/crawlstart/crawlstart.component.css
+++ b/src/app/crawlstart/crawlstart.component.css
@@ -23,12 +23,21 @@
   font-size: 11px;
   text-align: center;
   font-weight: bold;
+  margin: auto;
 }
 
 .nav-terms {
   padding: 0px;
   clear: both;
   margin: -57px 0 0 0
+}
+
+#label-inline{
+  display: inline;
+}
+
+#language{
+  display: inline;
 }
 
 .advsearch-navbar {
@@ -44,13 +53,92 @@
 .container {
   padding-left: 3.5%;
   float: left;
-  width: 70%;
+  width: 100%;
   margin-bottom: 5%;
 }
 
 .form-control {
-  width:135%;
   border-radius:0px
+}
+
+.label-section {
+  margin-left: 80px;
+}
+
+.label-bold{
+  font-weight: bold;
+}
+
+label{
+    font-weight: bold;
+    display: inline;
+} 
+
+#fieldset-1 input[type=text], textarea{
+  margin-left: 80px;
+}
+
+#fieldset-1 dt{
+  width: 35%;
+}
+
+#fieldset-1 dd{
+  width: 60%;
+}
+
+span{
+  margin-left: 10px;
+}
+
+#country-code-span{
+  margin-left: 7px;
+}
+
+.span-right{
+  margin-left: 0px;
+  margin-right: 10px;
+}
+
+.span-both{
+  margin: 0px 10px; 
+}
+
+.top-margin-div{
+  margin-top: 15px;
+}
+
+#fieldset-2 .label-bold{
+  font-weight: bold;
+}
+
+
+#checkbox-desc-1{
+  margin-left: 5px;
+}
+
+#checkbox-desc-2{
+  margin-left: 25px;
+}
+
+#directDocByURLID{
+  margin-left: 25px;
+}
+dl{
+    width: 75%;
+    margin-left: 20px;
+}
+
+dt{
+  text-align: left;
+  float: left; margin-top: 20px;
+  clear: left;
+  display: block;
+  position: relative;
+}
+
+dd{
+  float: left; margin-top: 20px;
+  display: block;
 }
 
 .adv-btn {
@@ -106,6 +194,12 @@
   text-align: center;
 }
 
+legend{
+    border-radius: 5px;
+    text-align: left;
+    color: red;
+}
+
 .link {
   margin-top:2px;
   font-weight: 700;
@@ -132,6 +226,20 @@ p {
 
 h2 {
   line-height: 1.8;
+}
+
+fieldset{
+  color: #18294A;
+  border: 0px solid #eeeeee;
+  border-radius: 5px;
+}
+
+#language{
+  width: 20%;
+}
+
+.dd-class{
+  width: 100%;
 }
 
 div {

--- a/src/app/crawlstart/crawlstart.component.html
+++ b/src/app/crawlstart/crawlstart.component.html
@@ -35,320 +35,336 @@
   </p>
   
   <hr>
-  <h3>Crawl Job</h3>
-  <p>A Crawl Job consist of one or more start points, crawl limitations and document freshness rules.</p>
-  <h4>Start Point</h4>
-  
-  <form>
-    <div class="row">
-
-      <div class="form-group">
-        
-        <div class="col-md-4"><label for="words">One Start URL or a list of URLs:
-          (must start with http:// https:// ftp:// smb:// file://):</label>
-        </div>
-
-        <div class="col-md-6">
-          <input [(ngModel)]="crawlvalues.crawlingMode" name="crawlingMode" 
-            value="url" type="radio">
-          <textarea [(ngModel)]="crawlvalues.crawlingURL" type="text" 
-            name="crawlingURL" class="form-control" id="words">
-          </textarea>
-        </div>
-
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4">
-          <label>From Link-List of URL</label>
-        </div>
-
-        <div class="col-md-6">
-          <input type="radio" [(ngModel)]="crawlvalues.crawlingMode" value="sitelist" name="crawlingMode">
-        </div>
-
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4">
-          <label for="any">from site-map</label>
-        </div>
-
-        <div class="col-md-6">
-          <input type="radio" [(ngModel)]="crawlvalues.crawlingMode" value="sitemap" name="crawlingMode">
-          <input type="text" class="form-control" id="any" 
-            [(ngModel)]="crawlvalues.sitemapURL" maxlength="256" name="sitemapURL">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4">
-          <label for="none">From File (enter a path
-          within your local file system)</label>
-        </div>
-
-        <div class="col-md-6">
-          <input type="radio" [(ngModel)]="crawlvalues.crawlingMode" value="file" name="crawlingMode">
-          <input type="text" class="form-control" id="none" 
-            [(ngModel)]="crawlvalues.crawlingFile" size="71" maxlength="256" name="crawlingFile">
-        </div>
-      </div>
-
-    </div>
-  </form>
-  <hr>
-
-  <h4>
-    Crawler Filter
-  </h4>
-  <p>These are limitations on the crawl stacker. The filters will be applied before a web page is loaded.</p>
-  <form>
-    <div class="row">
-      <div class="form-group">
-        <div class="col-md-4"><label for="language">Crawling Depth</label></div>
-        <div class="col-md-6"><input type="text" class="form-control" id="language" name="crawlingDepth" [(ngModel)]="crawlvalues.crawlingDepth" size="2" maxlength="2">
-          <input type="checkbox" [(ngModel)]="crawlvalues.directDocByURL" name="directDocByURL">also all linked non-parsable documents</div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label for="region">Unlimited crawl depth for URLs matching with</label></div>
-        <div class="col-md-6"><input type="text" name="crawlingDepthExtension" class="form-control" id="region" [(ngModel)]="crawlvalues.crawlingDepthExtension" size="40" maxlength="100">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label for="last update">Maximum Pages per Domain</label></div>
-        <div class="col-md-6">Use:<input type="checkbox" name="DomMaxCheck" [(ngModel)]="crawlvalues.crawlingDomMaxCheck">Page Count:
-          <input type="text" class="form-control" id="last update" name="DomMaxPages" [(ngModel)]="crawlvalues.crawlingDomMaxPages" size="6" maxlength="6">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4">
-          <label for="site">Miscelleneous contraints</label>
-        </div>
-        <div class="col-md-6"><input type="checkbox" [(ngModel)]="crawlvalues.crawlingQ" name="crawlingQ" id="site">Accept URLs with query-part ('?'):
-          <input type="checkbox" [(ngModel)]="crawlvalues.obeyHtmlRobotsNoIndex" name="obeyhtml"> Obey html-robots-noindex:
-          <input type="checkbox" [(ngModel)]="crawlvalues.obeyHtmlRobotsNoFollow" name="obeyhtml"> Obey html-robots-nofollow:
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label for="terms appearing">Load Filter on URLs
-          info</label>
-        </div>
-
-        <div class="col-md-6">
-          <img src="https://yacy.searchlab.eu/env/grafics/plus.gif">
-          must-match
-          <input type="radio" [(ngModel)]="crawlvalues.range" id="terms appearing" value="domain" name="range">Restrict to start domain(s)
-          <input type="radio" [(ngModel)]="crawlvalues.range" value="subpath" name="range">Restrict to sub-path(s)
-          <input [(ngModel)]="crawlvalues.range" type="radio" name="range">Use Filter
-          <input [(ngModel)]="crawlvalues.mustmatch" type="text" name="mustmatch" class="form-control" size="55" maxlength="100000" value=".*" onblur="if(this.value=='')this.value='.*;">
-          <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"> must-not-match
-          <input type="text" class="form-control" [(ngModel)]="crawlvalues.mustnotmatch" name="mustnotmatch" size="55" maxlength="100000">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label for="terms appearing">Load Filter on IPs</label></div> 
-        <div class="col-md-6">
-          <img src="https://yacy.searchlab.eu/env/grafics/plus.gif">
-          must-match
-          <input [(ngModel)]="crawlvalues.ipMustmatch" name="ipMustmatch" type="text" class="form-control" size="55" maxlength="100000" value=".*" onblur="if(this.value=='')this.value='.*;">
-          <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"> must-not-match
-          <input type="text" class="form-control" [(ngModel)]="crawlvalues.ipMustnotmatch" size="55" name="ipmustnotmatch" maxlength="100000">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4">Must-Match List for Country Codes</div>
-        <div class="col-md-6">
-          <input name="countryMustMatchSwitch" type="radio" [(ngModel)]="crawlvalues.countryMustMatchSwitch" value="0" [checked]="crawlvalues.countryMustMatchSwitch==='0'">
-          no country code restriction
-          <input name="countryMustMatchSwitch" [(ngModel)]="crawlvalues.countryMustMatchSwitch" id="countryMustMatchSwitch" value="1" type="radio" >Use filter
-          <input name="countryMustMatchList" [(ngModel)]="crawlvalues.countryMustMatchList" id="countryMustMatchList" type="text" size="60" maxlength="256">
-        </div>
-      </div>
-
-    </div>
-  </form>
-
-  <hr>
-  <h3>Document Filter</h3>
-  <p>These are limitations on index feeder. The filters will be applied after a web page was loaded.<p>
-  <form>
-    <div class="row">
-      <div class="form-group">
-
-        <div class="col-md-4">
-          <label>Filter On URLs</label>
-        </div>
-
-        <div class="col-md-6">
-          <img src="https://yacy.searchlab.eu/env/grafics/plus.gif">
-           must match
-          <input name="index" [(ngModel)]="crawlvalues.indexmustmatch" type="text" class="form-control">
-          <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"> must-not-match
-          <input name="index" [(ngModel)]="crawlvalues.indexmustnotmatch" type="text" class="form-control">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Filter on Content of Document
-          (all visible text, including camel-case-tokenized url and title)</label></div>
-        <div class="col-md-6">
-          <img src="https://yacy.searchlab.eu/env/grafics/plus.gif"> must match
-          <input name="index" [(ngModel)]="crawlvalues.indexcontentmustmatch" type="text" size="55" class="form-control" maxlength="100000">
-          <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"> must-not-match
-          <input name="index" [(ngModel)]="crawlvalues.indexcontentmustnotmatch" type="text" class="form-control"></div >
-      </div>
-
-    </div>
-  </form>
-
-  <hr>
-  <h3>Clean-Up before Crawl Start</h3>
-  <form>
-    <div class="row">
-      <div class="form-group">
-
-        <div class="col-md-4">
-          <label>No Deletion</label>
-        </div>
-
-        <div class="col-md-6">
-          <input name="deleteold" [(ngModel)]="crawlvalues.deleteold" value="off" type="radio">Do not delete any document before the crawl is started.
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Delete sub-path</label></div>
-        <div class="col-md-6">
-          <input name="deleteold" [(ngModel)]="crawlvalues.deleteold" value="on" type="radio">For each host in the start url list, delete all documents (in the given subpath) from that host.
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Delete only old</label></div>
-        <div class="col-md-6">
-          <input name="deleteold" [(ngModel)]="crawlvalues.deleteold" value="age" type="radio">Treat documents that were loaded before as stale and delete them before the crawl is started.
-        </div>
-      </div>
-  </div>
-  </form>
-
-  <hr>
-  <h3>Double-Check Rules</h3>
-  <form>
-    <div class="row">
-      <div class="form-group">
-        <div class="col-md-4"><label>No Doubles</label></div>
-
-        <div class="col-md-6">
-          <input name="recrawl" [(ngModel)]="crawlvalues.recrawl" value="nodoubles" type="radio">Never load any page that is already known. Only the start-url may be loaded again
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Reload</label></div>
-
-        <div class="col-md-6">
-          <input name="recrawl" [(ngModel)]="crawlvalues.recrawl" value="nodobles" type="radio">Treat documents that were loaded before as stale and load them again. If they are younger, they are ignored.
-        </div>
-
-      </div>
-    </div>
-  </form>
-
-  <hr>
-  <h3>Document Cache</h3>
-  <form>
-    <div class="row">
-      <div class="form-group">
-        <div class="col-md-4"><label>Store to Web Cache</label></div>
-
-        <div class="col-md-6">
-          <input name="storeHT" [(ngModel)]="crawlvalues.storeHTCache" type="checkbox">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Policy for usage of Web Cache</label></div>
-        
-        <div class="col-md-6">
-          <input name="cache" [(ngModel)]="crawlvalues.cachePolicy" type="radio" value="nocache">no cache
-          <input name="cachepolicy" type="radio" [(ngModel)]="crawlvalues.cachePolicy" value="iffresh">if fresh
-          <input name="cachepolicy" type="radio" [(ngModel)]="crawlvalues.cachePolicy" value="ifexist">if exist
-          <input name="cachepolicy" type="radio" [(ngModel)]="crawlvalues.cachePolicy" value="cacheonly">cache only
-        </div>
-
-      </div>
-    </div>
-  </form>
-
-  <hr>
-  <h3>Snapshot Creation</h3>
-  <form>
-    <div class="row">
-      <div class="form-group">
-        <div class="col-md-4"><label>Max Depth for Snapshots</label></div>
-        <div class="col-md-6">
-          <input type="text" name="snapshotsmaxdepth" class="form-control" [(ngModel)]="crawlvalues.snapshotsMaxDepth" size="2" maxlength="2" value="-1">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Multiple Snapshot Versions</label></div>
-        <div class="col-md-6"><input name="replaceold" [(ngModel)]="crawlvalues.snapshotsReplaceOld" value="on" type="radio">replace old snapshots with new ones
-          <input name="replaceold" type="radio" value="off" [(ngModel)]="crawlvalues.snapshotsReplaceOld">add new versions for each crawl
-        </div>
-
-        <div class="form-group">
-          <div class="col-md-4">
-            <label>
-              <img src="https://yacy.searchlab.eu/env/grafics/minus.gif">must-not-match filter for snapshot generation
-            </label>
+  <fieldset>  
+    <legend>Crawl Job</legend>
+    <p>A Crawl Job consist of one or more start points, crawl limitations and document freshness rules.</p><br/>
+    <fieldset id="fieldset-1">  
+      <legend>Start Point</legend>
+      <dl>
+        <form>
+          <div class="row">
+            <div class="form-group">
+              <dt>
+                <input [(ngModel)]="crawlvalues.crawlingMode" name="crawlingMode" 
+                    value="url" type="radio">
+                <label for="words" class="label-inline">One Start URL or a list of URLs:<br>
+                  (must start with http:// https:// ftp:// smb:// file://):</label>
+              </dt>
+              <dd>
+                  <textarea [(ngModel)]="crawlvalues.crawlingURL" type="text" 
+                    name="crawlingURL" class="form-control" id="words" cols="64" rows="3" size="41" >
+                  </textarea>
+              </dd>
+            </div>
+            <br/>
+            <div class="form-group">
+              <dt>
+                <input type="radio" [(ngModel)]="crawlvalues.crawlingMode" value="sitelist" name="crawlingMode">
+                <label class="label-inline">From Link-List of URL</label>
+              </dt>
+            </div>
+            <div class="form-group">
+              <dt>
+                <input type="radio" [(ngModel)]="crawlvalues.crawlingMode" value="sitemap" name="crawlingMode">
+                <label for="any" class="label-inline">From Sitemap</label>
+              </dt>
+              <dd>
+                <input type="text" class="form-control" id="any" 
+                  [(ngModel)]="crawlvalues.sitemapURL" maxlength="256" name="sitemapURL">
+              </dd>
+            </div>
+            <div class="form-group">
+              <dt>
+                <input type="radio" [(ngModel)]="crawlvalues.crawlingMode" value="file" name="crawlingMode">
+                <label for="none" class="label-inline">From File (enter a path <br/> within your local file system)</label>
+              </dt>
+              <dd>
+                <input type="text" class="form-control" id="none" 
+                  [(ngModel)]="crawlvalues.crawlingFile" size="71" maxlength="256" name="crawlingFile">
+              </dd>
+            </div>
+          </div>
+        </form>
+      </dl>
+    </fieldset>
+    <hr>
+    <fieldset>
+      <legend>Crawler Filter</legend>
+      <p>These are limitations on the crawl stacker. The filters will be applied before a web page is loaded.</p>
+      <form>
+        <div class="row">
+          <div class="form-group">
+            <div class="col-md-4"><label for="language">Crawling Depth</label></div>
+            <div class="col-md-6">
+              <input type="text" class="form-control" id="language" name="crawlingDepth" [(ngModel)]="crawlvalues.crawlingDepth" size="2" maxlength="2"><br/>
+              <input type="checkbox" [(ngModel)]="crawlvalues.directDocByURL" name="directDocByURL"><span>Also all linked non-parsable documents</span></div>
           </div>
 
-          <div class="col-md-6">
-            <input name="mustnotmatch" type="text" [(ngModel)]="crawlvalues.snapshotsMustnotmatch" size="55" class="form-control" maxlength="100000">
+          <div class="form-group">
+            <div class="col-md-4"><label for="region">Unlimited crawl depth for URLs matching with</label></div>
+            <div class="col-md-6">
+              <input type="text" name="crawlingDepthExtension" class="form-control" id="region" [(ngModel)]="crawlvalues.crawlingDepthExtension" size="40" maxlength="100">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4"><label for="last update">Maximum Pages per Domain</label></div>
+            <div class="col-md-6">
+              <input type="checkbox" name="DomMaxCheck" [(ngModel)]="crawlvalues.crawlingDomMaxCheck"><span>Use Page Count:</span>
+              <input type="text" class="form-control" id="last update" name="DomMaxPages" [(ngModel)]="crawlvalues.crawlingDomMaxPages" size="6" maxlength="6">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4">
+              <label for="site">Miscelleneous contraints</label>
+            </div>
+            <div class="col-md-6">
+              <input type="checkbox" [(ngModel)]="crawlvalues.crawlingQ" name="crawlingQ" id="site"><span>Accept URLs with query-part ('?'):</span><br>
+              <input type="checkbox" [(ngModel)]="crawlvalues.obeyHtmlRobotsNoIndex" name="obeyhtml"><span>Obey html-robots-noindex:</span><br>
+              <input type="checkbox" [(ngModel)]="crawlvalues.obeyHtmlRobotsNoFollow" name="obeyhtml"><span>Obey html-robots-nofollow:</span>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4">
+              <label for="terms appearing">Load Filter on URLs info</label>
+            </div>
+
+            <div class="col-md-6">
+              <img src="https://yacy.searchlab.eu/env/grafics/plus.gif">
+              <span>must-match</span><br/>
+              <input type="radio" [(ngModel)]="crawlvalues.range" id="terms appearing" value="domain" name="range"><span>Restrict to start domain(s)</span><br/>
+              <input type="radio" [(ngModel)]="crawlvalues.range" value="subpath" name="range"><span>Restrict to sub-path(s)</span><br/>
+              <input [(ngModel)]="crawlvalues.range" type="radio" name="range"><span>Use Filter</span><br/>
+              <input [(ngModel)]="crawlvalues.mustmatch" type="text" name="mustmatch" class="form-control" size="55" maxlength="100000" value=".*" onblur="if(this.value=='')this.value='.*;">
+              <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"><span>must-not-match</span>
+              <input type="text" class="form-control" [(ngModel)]="crawlvalues.mustnotmatch" name="mustnotmatch" size="55" maxlength="100000">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4"><label for="terms appearing">Load Filter on IPs</label></div> 
+            <div class="col-md-6">
+              <img src="https://yacy.searchlab.eu/env/grafics/plus.gif">
+              <span>must-match</span>
+              <input [(ngModel)]="crawlvalues.ipMustmatch" name="ipMustmatch" type="text" class="form-control" size="55" maxlength="100000" value=".*" onblur="if(this.value=='')this.value='.*;">
+              <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"><span>must-not-match</span>
+              <input type="text" class="form-control" [(ngModel)]="crawlvalues.ipMustnotmatch" size="55" name="ipmustnotmatch" maxlength="100000">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4"><span class="label-bold">Must-Match List for Country Codes</span></div>
+            <div class="col-md-6">
+              <input name="countryMustMatchSwitch" type="radio" [(ngModel)]="crawlvalues.countryMustMatchSwitch" value="0" [checked]="crawlvalues.countryMustMatchSwitch==='0'">
+              <span id="country-code-span">No country code restriction</span><br/>
+              <input name="countryMustMatchSwitch" [(ngModel)]="crawlvalues.countryMustMatchSwitch" id="countryMustMatchSwitch" value="1" type="radio"><span class="span-both">Use filter</span>
+              <input name="countryMustMatchList" [(ngModel)]="crawlvalues.countryMustMatchList" id="countryMustMatchList" type="text" size="60" maxlength="256">
+            </div>
+          </div>
+        </div>
+      </form>
+    </fieldset>
+
+    <hr>
+    <fieldset>
+      <legend>Document Filter</legend>
+      <p>These are limitations on index feeder. The filters will be applied after a web page was loaded.<p>
+      <form>
+        <div class="row">
+          <div class="form-group">
+            <div class="col-md-4">
+              <label>Filter On URLs</label>
+            </div>
+            <div class="col-md-6">
+              <img src="https://yacy.searchlab.eu/env/grafics/plus.gif"><span>must match</span>
+              <input name="index" [(ngModel)]="crawlvalues.indexmustmatch" type="text" class="form-control">
+              <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"><span>must-not-match</span>
+              <input name="index" [(ngModel)]="crawlvalues.indexmustnotmatch" type="text" class="form-control">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4">
+              <label>Filter on Content of Document<br/>
+              (all visible text, including camel-case-tokenized url and title)</label>
+            </div>
+            <div class="col-md-6">
+              <img src="https://yacy.searchlab.eu/env/grafics/plus.gif"><span>must match</span>
+              <input name="index" [(ngModel)]="crawlvalues.indexcontentmustmatch" type="text" size="55" class="form-control" maxlength="100000">
+              <img src="https://yacy.searchlab.eu/env/grafics/minus.gif"><span>must-not-match</span>
+              <input name="index" [(ngModel)]="crawlvalues.indexcontentmustnotmatch" type="text" class="form-control"></div >
+          </div>
+        </div>
+      </form>
+    </fieldset>
+
+    <hr>
+    <fieldset>
+      <legend>Clean-Up before Crawl Start</legend>
+      <form>
+        <div class="row">
+          <div class="form-group">
+
+            <div class="col-md-4">
+              <label>No Deletion</label>
+            </div>
+
+            <div class="col-md-6">
+              <input name="deleteold" [(ngModel)]="crawlvalues.deleteold" value="off" type="radio">
+              <span> Do not delete any document before the crawl is started.</span>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4"><label>Delete sub-path</label></div>
+            <div class="col-md-6">
+              <input name="deleteold" [(ngModel)]="crawlvalues.deleteold" value="on" type="radio">
+              <span> For each host in the start url list, delete all documents (in the given subpath) from that host.</span>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4"><label>Delete only old</label></div>
+            <div class="col-md-6">
+              <input name="deleteold" [(ngModel)]="crawlvalues.deleteold" value="age" type="radio">
+              <span> Treat documents that were loaded before as stale and delete them before the crawl is started.</span>
+            </div>
+          </div>
+        </div>
+      </form>
+    </fieldset>
+
+    <hr>
+    <fieldset>
+      <legend>Double-Check Rules</legend>
+      <form>
+        <div class="row">
+          <div class="form-group">
+            <div class="col-md-4">
+              <label>No Doubles</label>
+            </div>
+
+            <div class="col-md-6">
+              <input name="recrawl" [(ngModel)]="crawlvalues.recrawl" value="nodoubles" type="radio">
+              <span>Never load any page that is already known. Only the start-url may be loaded again</span>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4">
+              <label>Reload</label>
+            </div>
+
+            <div class="col-md-6">
+              <input name="recrawl" [(ngModel)]="crawlvalues.recrawl" value="nodobles" type="radio">
+              <span>Treat documents that were loaded before as stale and load them again. If they are younger, they are ignored.</span>
+            </div>
+
+          </div>
+        </div>
+      </form>
+    </fieldset>
+
+    <hr>
+    <fieldset>
+      <legend>Document Cache</legend>
+      <form>
+        <div class="row">
+          <div class="form-group">
+            <div class="col-md-4">
+              <label>Store to Web Cache</label>
+            </div>
+
+            <div class="col-md-6">
+              <input name="storeHT" [(ngModel)]="crawlvalues.storeHTCache" type="checkbox">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4"><label>Policy for usage of Web Cache</label></div>
+            
+            <div class="col-md-6">
+              <input name="cache" [(ngModel)]="crawlvalues.cachePolicy" type="radio" value="nocache"><span class="span-both">no cache</span><br/>
+              <input name="cachepolicy" type="radio" [(ngModel)]="crawlvalues.cachePolicy" value="iffresh"><span class="span-both">if fresh</span><br/>
+              <input name="cachepolicy" type="radio" [(ngModel)]="crawlvalues.cachePolicy" value="ifexist"><span class="span-both">if exist</span><br/>
+              <input name="cachepolicy" type="radio" [(ngModel)]="crawlvalues.cachePolicy" value="cacheonly"><span class="span-both">cache only</span><br/>
+            </div>
+
+          </div>
+        </div>
+      </form>  
+    </fieldset>
+    
+    <hr>
+    <fieldset>
+      <legend>Snapshot Creation</legend>
+      <form>
+        <div class="row">
+          <div class="form-group">
+            <div class="col-md-4"><label>Max Depth for Snapshots</label></div>
+            <div class="col-md-6">
+              <input type="text" name="snapshotsmaxdepth" class="form-control" [(ngModel)]="crawlvalues.snapshotsMaxDepth" size="2" maxlength="2" value="-1">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4"><label>Multiple Snapshot Versions</label></div>
+            <div class="col-md-6"><input name="replaceold" [(ngModel)]="crawlvalues.snapshotsReplaceOld" value="on" type="radio"><span class="span-both">Replace old snapshots with new ones</span><br/>
+              <input name="replaceold" type="radio" value="off" [(ngModel)]="crawlvalues.snapshotsReplaceOld"><span class="span-both">Add new versions for each crawl</span><br/>
+            </div>
+
+            <div class="form-group">
+              <div class="col-md-4 top-margin-div">
+                <label> must-not-match filter for snapshot generation </label>
+              </div>
+
+              <div class="col-md-6">
+                <input name="mustnotmatch" type="text" [(ngModel)]="crawlvalues.snapshotsMustnotmatch" size="55" class="form-control" maxlength="100000">
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </form>
+    </fieldset>
+
+    <hr>
+    <fieldset>
+      <legend>Index Attributes</legend>
+      <form>
+        <div class="row">
+          <div class="form-group">
+            <div class="col-md-4 top-margin-div"><label>Indexing</label></div>
+            <div class="col-md-6">
+              <input name="indextext" type="checkbox" [(ngModel)]="crawlvalues.indexText"><span>index text</span><br/>
+              <input name="indexmedia" type="checkbox" [(ngModel)]="crawlvalues.indexMedia"><span>index media</span>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4 top-margin-div"><label>Add Crawl result to collection(s)</label></div>
+            <div class="col-md-6">
+              <input name="collection" type="text" [(ngModel)]="crawlvalues.collection" size="60" class="form-control" maxlength="100">
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-4 top-margin-div"><label>Time Zone Offset info </label></div>
+            <div class="col-md-6"><input name="timezoneoffset" type="text" [(ngModel)]="crawlvalues.timezoneOffset" size="4" maxlength="4" class="form-control">
+            </div>
           </div>
 
         </div>
-      </div>
+      </form>
+    </fieldset>
+    
+
+    <div class="adv-submit" id="crawlStartBtn">
+      <button class="adv-btn btn" (click)="startCrawlJob()"><span class="btn-text">Start New Crawl Job</span></button>
     </div>
-  </form>
-
-  <hr>
-  <h3>Index Attributes</h3>
-  <form>
-    <div class="row">
-      <div class="form-group">
-        <div class="col-md-4"><label>Indexing</label></div>
-        <div class="col-md-6"><input name="indextext" type="checkbox" [(ngModel)]="crawlvalues.indexText">
-          index text: <input name="indexmedia" type="checkbox" [(ngModel)]="crawlvalues.indexMedia">index media
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Add Crawl result to collection(s)</label></div>
-        <div class="col-md-6"><input name="collection" type="text" [(ngModel)]="crawlvalues.collection" size="60" class="form-control" maxlength="100">
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-md-4"><label>Time Zone Offset info </label></div>
-        <div class="col-md-6"><input name="timezoneoffset" type="text" [(ngModel)]="crawlvalues.timezoneOffset" size="4" maxlength="4" class="form-control">
-        </div>
-      </div>
-
-    </div>
-  </form>
-
-  <div class="adv-submit">
-    <button class="adv-btn btn" (click)="startCrawlJob()"><span class="btn-text">Start New Crawl Job</span></button>
-  </div>
+  </fieldset>
 
 </div>
 


### PR DESCRIPTION
Fixes issue #769 

Design changes have been made as given here: http://yacy.searchlab.eu/CrawlStartExpert.html 

Changes:
1. The entire form was put in a fieldset with legends, and this was further divided into fieldsets as given on the above mentioned link.
2. The radio buttons of the start point section were left aligned.
3. The labels were made bold as given in the above link
4. The legends have been given red colour so as to use the existing design of the UI
5. Other than the above, the page has been made uncluttered. In some cases, the checkboxes and radio buttons have been put on separate lines, and the text beside them has been given margin for the same purpose.

Screenshots for the change:
![merge_from_ofoct 1](https://user-images.githubusercontent.com/26062692/32711900-6fb499c4-c867-11e7-98a3-b3e745327596.jpg)

Link for the changes:
The changes made can be viewed here:
https://remorax.github.io/susper.com/crawlstartexpert

@harshit98 @Orbiter @mariobehling I closed the previous PR because there were a lot of commits and I was unable to squash them, and update my fork. Please review this PR :)