### PR TITLE
Fixed #634 : no empty images are displayed

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -108,12 +108,12 @@
           <div *ngIf="totalNumber > 0">
             <div *ngFor="let item of items;let i = index">
               <div class="item">
-                <img src="{{item.link}}" height="200px" (click)="expandImage(i)" [ngClass]="'image'+i">
-              </div>
-              <div class=" item image-viewer" *ngIf="expand && expandedrow === i">
-                <span class="helper"></span>
-                <img [src]="items[expandedkey].link" height="200px" style="vertical-align: middle;">
-              </div>
+                <img src="{{item.image}}" height="200px" (click)="expandImage(i)" [ngClass]="'image'+i">
+            </div>
+            <div class=" item image-viewer" *ngIf="expand && expandedrow === i">
+              <span class="helper"></span>
+              <img [src]="items[expandedkey].image" height="200px" style="vertical-align: middle;">
+            </div>
 
             </div>
 


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #634 : no empty images are displayed

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

- surge link: https://pr-943-fossasia-susper.surge.sh

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- As I saw, the #634 issue's priority is `URGENT` and no one solved it, so I did it. I changed the src of the images so empty pictures will not be displayed anymore.

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
### Before
![before](https://user-images.githubusercontent.com/33882273/37462564-1eb54826-285b-11e8-879a-46c6d10f0c45.jpg)


### After
![after](https://user-images.githubusercontent.com/33882273/37462568-21d9aa10-285b-11e8-9d2a-f9680502d260.jpg)
