### PR TITLE
Fixed #862 : GitHub icon redirects user to FOSSASIA GitHub page

### DIFF
--- a/src/app/dropdown/dropdown.component.html
+++ b/src/app/dropdown/dropdown.component.html
@@ -17,7 +17,7 @@
             <p>Code</p>
           </a>
 
-          <a class="menu-item" href="//github.com/fossasia/susper.com" target="_blank">
+          <a class="menu-item" href="//github.com/fossasia" target="_blank">
             <div class="img"><img src="../../assets/images/github.png"></div>
             <p>Github</p>
           </a>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #862 : GitHub icon redirects user to FOSSASIA GitHub page

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- On the DropDown widget there were two icons pointing to Susper's repository from GitHub. I modified the href of the GitHub icon and now it redirects the user to FOSSASIA's GitHub page since Code icon redirects user to Susper's repository.

<!-- Demo Link: Add here the link where you changes can be seen. -->

- Surge link: https://pr-955-fossasia-susper.surge.sh/
