### PR TITLE
FIXES #952: Footer comes up in the search settings page

### DIFF
--- a/src/app/searchsettings/searchsettings.component.css
+++ b/src/app/searchsettings/searchsettings.component.css
@@ -208,3 +208,10 @@ ul li{
 .active {
   color:#dd4b39
 }
+
+footer {
+  width: 100%;
+  bottom: 0px;
+  position: absolute;
+}
+


### PR DESCRIPTION
Fixed the bug that footer is appearing little up in the search settings page

Fixes #952

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-16-fossasia-susper.surge.sh -->

https://pr-963-fossasia-susper.surge.sh

#### Changes proposed in this pull request:

changes were made to  [searchsettings.component.css]


**Screenshot after fix**
![screencapture-localhost-4200-preferences-2018-03-27-00_40_35](https://user-images.githubusercontent.com/31608680/37927523-fffbfe60-3157-11e8-8258-939dbc3affd5.png)

