### PR TITLE
 Fixes:# 967 prevented the link from analytics  being  re appende again and again to…

### DIFF
--- a/src/app/statsbox/statsbox.component.ts
+++ b/src/app/statsbox/statsbox.component.ts
@@ -62,8 +62,10 @@ export class StatsboxComponent implements OnInit {
 
   changequerylook(modifier, element) {
     let querylook = Object.assign({}, this.querylook);
-
+    let check = new RegExp( decodeURIComponent(modifier));
+    if (!check.test(querylook['query'])){   
     querylook['query'] = this.querylook['query'] + ' ' + decodeURIComponent(modifier);
+  }
     return querylook;
   }
 

--- a/src/app/statsbox/statsbox.component.ts
+++ b/src/app/statsbox/statsbox.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
-import {Store} from '@ngrx/store';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Store } from '@ngrx/store';
 import * as fromRoot from '../reducers';
-import {Observable} from 'rxjs';
-import {SearchService} from '../services/search.service';
+import { Observable } from 'rxjs';
+import { SearchService } from '../services/search.service';
 import { ThemeService } from '../services/theme.service';
 @Component({
   selector: 'app-statsbox',
@@ -49,7 +49,7 @@ export class StatsboxComponent implements OnInit {
   changeurl(modifier, element) {
     this.querylook['query'] = this.querylook['query'] + '+' + decodeURIComponent(modifier);
     this.selectedelements.push(element);
-    this.route.navigate(['/search'], {queryParams: this.querylook});
+    this.route.navigate(['/search'], { queryParams: this.querylook });
   }
 
   selectelement(element) {
@@ -62,16 +62,16 @@ export class StatsboxComponent implements OnInit {
 
   changequerylook(modifier, element) {
     let querylook = Object.assign({}, this.querylook);
-    let check = new RegExp( decodeURIComponent(modifier));
-    if (!check.test(querylook['query'])){   
-    querylook['query'] = this.querylook['query'] + ' ' + decodeURIComponent(modifier);
-  }
+    let check = new RegExp(decodeURIComponent(modifier));
+    if (!check.test(querylook['query'])) {
+      querylook['query'] = this.querylook['query'] + ' ' + decodeURIComponent(modifier);
+    }
     return querylook;
   }
 
   removeurl(modifier) {
     this.querylook['query'] = this.querylook['query'].replace('+' + decodeURIComponent(modifier), '');
-    this.route.navigate(['/search'], {queryParams: this.querylook});
+    this.route.navigate(['/search'], { queryParams: this.querylook });
   }
 
   constructor(
@@ -93,8 +93,8 @@ export class StatsboxComponent implements OnInit {
             let datalabels = [];
 
             for (let element of nav.elements) {
-                datalabels.push(element.name);
-                data.push(parseInt(element.count, 10));
+              datalabels.push(element.name);
+              data.push(parseInt(element.count, 10));
             }
 
             this.barChartData[0].data = data;
@@ -106,7 +106,7 @@ export class StatsboxComponent implements OnInit {
 
     this.searchresults$ = store.select(fromRoot.getItems);
 
-    this.searchresults$.subscribe( searchresults => {
+    this.searchresults$.subscribe(searchresults => {
       this.getChartData(searchresults);
     });
 


### PR DESCRIPTION
… query

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes :#967

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->
https://pr-#968-fossasia-susper.surge.sh

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
Prevented the re appending of Query modifier from analytics  again and again

<!-- Demo Link: Add here the link where you changes can be seen. -->

-src/app/statsbox/statsbox.component.ts

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
<img width="1440" alt="screen shot 2018-03-29 at 11 01 53 pm" src="https://user-images.githubusercontent.com/28914919/38104026-a1f0438a-33a5-11e8-8492-e2e09382ad6b.png">
 
