### PR TITLE
Fixes:#977 prevented from appending the same filter two times when clicked to th…

### DIFF
--- a/src/app/advancedsearch/advancedsearch.component.ts
+++ b/src/app/advancedsearch/advancedsearch.component.ts
@@ -18,6 +18,7 @@ export class AdvancedsearchComponent implements OnInit {
     this.querylook['query'] = this.querylook['query'] + '+' + decodeURIComponent(modifier);
     this.selectedelements.push(element);
     this.route.navigate(['/search'], {queryParams: this.querylook});
+    return false;
   }
 
   removeurl(modifier) {


### PR DESCRIPTION
…e seach query

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #:977

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [ ] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Prevented from appending the search filter two times for the search query when clicked on a filter

<!-- Demo Link: Add here the link where you changes can be seen. -->

-src/app/advancedsearch/advancedsearch.component.ts

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
-
<img width="1440" alt="screen shot 2018-04-05 at 7 06 47 pm" src="https://user-images.githubusercontent.com/28914919/38369102-95bf58e4-3904-11e8-8745-29d90dcd9f60.png">

