### PR TITLE
nokogiri version in Gem.lock file was updated to vesrion 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,11 +102,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     maruku (0.7.0)
     mercenary (0.3.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.10.0)
@@ -156,4 +156,4 @@ DEPENDENCIES
   percy-cli
 
 BUNDLED WITH
-   1.13.6
+   1.16.0


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->
 https://pr-982-fossasia-susper.surge.sh

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
-The version of the nokogiri of the Gem.lock file was updated to version 1.8.2 using the bundler

<!-- Demo Link: Add here the link where you changes can be seen. -->

-Gemfile.lock

