### PR TITLE
Fixes #797 and #181:Used Wikipedia API to implement infobox.

### DIFF
--- a/src/app/advancedsearch/advancedsearch.component.spec.ts
+++ b/src/app/advancedsearch/advancedsearch.component.spec.ts
@@ -28,7 +28,7 @@ describe('AdvancedsearchComponent', () => {
         StoreModule.provideStore(reducer)
       ],
       declarations: [
-        AdvancedsearchComponent,
+        AdvancedsearchComponent
       ]
     })
       .compileComponents();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -31,6 +31,7 @@ import {StatsboxComponent} from "./statsbox/statsbox.component";
 import {SpeechService} from "./services/speech.service";
 import {InfiniteScrollModule} from "ngx-infinite-scroll";
 import {ChartsModule} from "ng2-charts";
+import { InfoboxComponent } from './infobox/infobox.component';
 
 describe('AppComponent', () => {
   beforeEach(() => {
@@ -45,7 +46,7 @@ describe('AppComponent', () => {
         JsonpModule,
         ChartsModule,
         StoreModule.provideStore(reducer),
-        StoreDevtoolsModule.instrumentOnlyWithExtension(),
+        StoreDevtoolsModule.instrumentOnlyWithExtension()
       ],
       declarations: [
         AppComponent,
@@ -65,7 +66,8 @@ describe('AppComponent', () => {
         IntelligenceComponent,
         SpeechtotextComponent,
         AutoCorrectComponent,
-        StatsboxComponent
+        StatsboxComponent,
+        InfoboxComponent
       ],
       providers: [
         SpeechService

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,8 @@ import {AutocorrectService} from "./services/autocorrect.service";
 import { SpeechSynthesisService } from './services/speech-synthesis.service';
 import {InfiniteScrollModule} from "ngx-infinite-scroll";
 import { ChartsModule } from 'ng2-charts/ng2-charts';
+import { InfoboxComponent } from './infobox/infobox.component';
+import { KnowledgeapiService } from './services/knowledgeapi.service';
 
 const appRoutes: Routes = [
   {path: 'search', component: ResultsComponent},
@@ -81,6 +83,7 @@ const appRoutes: Routes = [
     SpeechtotextComponent,
     AutoCorrectComponent,
     StatsboxComponent,
+    InfoboxComponent,
   ],
 
   imports: [
@@ -106,7 +109,8 @@ const appRoutes: Routes = [
     CrawlstartService,
     IntelligenceService,
     AutocorrectService,
-    SpeechSynthesisService
+    SpeechSynthesisService,
+    KnowledgeapiService
   ],
 
   bootstrap: [AppComponent]

--- a/src/app/infobox/infobox.component.css
+++ b/src/app/infobox/infobox.component.css
@@ -1,0 +1,31 @@
+.card {
+  /* Add shadows to create the "card" effect */
+  border: 1px solid rgba(150,150,150,0.3);
+  border-bottom-color: rgba(125,125,125,0.3);
+  margin-bottom: 16px;
+  padding: 22px 22px 18px 22px;
+  transition: 0.3s;
+  width: 100%;
+  margin-left: 20px;
+}
+
+/* Add some padding inside the card container */
+.card-container {
+  padding: 2px 16px;
+}
+
+/* Heading */
+h2 {
+  font-size: 2.6em;
+}
+
+/* Description */
+p {
+  line-height: 20px;
+  font-family: Arial, sans-serif;
+  font-size: 13px;
+}
+a {
+  color: #1a0dab;
+  text-decoration: none;
+}

--- a/src/app/infobox/infobox.component.html
+++ b/src/app/infobox/infobox.component.html
@@ -1,0 +1,6 @@
+<div *ngIf="this.description" class="card">
+    <div>
+      <h2><b>{{this.title}}</b></h2>
+      <p>{{this.description | slice:0:600}}<a href='https://en.wikipedia.org/wiki/{{this.title}}'>..more at Wikipedia</a></p>
+    </div>
+</div>

--- a/src/app/infobox/infobox.component.spec.ts
+++ b/src/app/infobox/infobox.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { InfoboxComponent } from './infobox.component';
 import {AppComponent} from "../app.component";
 import {NavbarComponent} from "../navbar/navbar.component";
 import {IndexComponent} from "../index/index.component";
@@ -15,22 +16,14 @@ import {BrowserModule} from "@angular/platform-browser";
 import {CommonModule} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {HttpModule, JsonpModule} from "@angular/http";
+import {KnowledgeapiService} from "../services/knowledgeapi.service";
 import {reducer} from "../reducers/index";
 import {StoreModule} from "@ngrx/store";
 import {StoreDevtoolsModule} from "@ngrx/store-devtools";
-import {AutoCompleteComponent} from "../auto-complete/auto-complete.component";
-import { ThemeComponent } from '../theme/theme.component';
-import { DropdownComponent } from '../dropdown/dropdown.component';
-import {IntelligenceComponent} from "../intelligence/intelligence.component";
-import {IntelligenceService} from "../services/intelligence.service";
-import {AutoCorrectComponent} from "../auto-correct/auto-correct.component";
-import { ThemeService } from '../services/theme.service';
-import {KnowledgeapiService} from "../services/knowledgeapi.service";
-import {InfoboxComponent} from "../infobox/infobox.component";
 
-describe('IntelligenceComponent', () => {
-  let component: IntelligenceComponent;
-  let fixture: ComponentFixture<IntelligenceComponent>;
+describe('InfoboxComponent', () => {
+  let component: InfoboxComponent;
+  let fixture: ComponentFixture<InfoboxComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -42,25 +35,31 @@ describe('IntelligenceComponent', () => {
         HttpModule,
         JsonpModule,
         StoreModule.provideStore(reducer),
+        StoreDevtoolsModule.instrumentOnlyWithExtension(),
       ],
       declarations: [
-        IntelligenceComponent
-      ],
+        AppComponent,
+        NavbarComponent,
+        IndexComponent,
+        ResultsComponent,
+        NotFoundComponent,
+        AdvancedsearchComponent,
+        SearchBarComponent,
+        FooterNavbarComponent,
+        AboutComponent,
+        ContactComponent,
+        ModalComponent,
+        InfoboxComponent ],
       providers: [
-        IntelligenceService,
-        ThemeService
+        KnowledgeapiService
       ],
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(IntelligenceComponent);
+    fixture = TestBed.createComponent(InfoboxComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
   });
 });

--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -1,0 +1,42 @@
+import {Component, OnInit, ChangeDetectorRef} from '@angular/core';
+import {Router, ActivatedRoute} from '@angular/router';
+import {Store} from '@ngrx/store';
+import * as fromRoot from '../reducers';
+import {KnowledgeapiService} from '../services/knowledgeapi.service';
+
+@Component({
+  selector: 'app-infobox',
+  templateUrl: './infobox.component.html',
+  styleUrls: ['./infobox.component.css']
+})
+export class InfoboxComponent implements OnInit {
+  public title: string;
+  public description: string;
+  query$: any;
+  resultsearch = '/search';
+  constructor(private knowledgeservice: KnowledgeapiService,
+              private route: Router,
+              private activatedroute: ActivatedRoute,
+              private store: Store<fromRoot.State>,
+              private ref: ChangeDetectorRef) {
+    this.query$ = store.select(fromRoot.getquery);
+    this.query$.subscribe( query => {
+      if (query) {
+        this.knowledgeservice.getsearchresults(query).subscribe(res => {
+          const pageId = Object.keys(res)[0];
+          if (res[pageId].extract) {
+            this.title = res[pageId].title;
+            this.description = res[pageId].extract;
+          } else {
+            this.title = '';
+            this.description = '';
+          }
+        });
+      }
+    });
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -174,11 +174,6 @@ a {
   cursor: pointer;
 }
 
-.infobox {
-  display: inline-block;
-  float: left;
-}
-
 .item img {
   max-width: 100%;
   max-height: 100%;
@@ -270,7 +265,9 @@ a {
 .dropdown-menu {
   float: right;
 }
-
+.infobox{
+  margin-top: -110px;
+}
 .dropdown {
   left: 38%;
   width: 0;

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -78,6 +78,7 @@
             </div>
           </div>
           <div class="infobox">
+            <app-infobox [hidden]="hidefooter" class="infobox col-md-4" *ngIf="Display('all')"></app-infobox>
             <app-statsbox [hidden]="hidefooter || hideAutoCorrect || totalNumber < 1" *ngIf="Display('all')"></app-statsbox>
           </div>
         </div>

--- a/src/app/results/results.component.spec.ts
+++ b/src/app/results/results.component.spec.ts
@@ -37,6 +37,8 @@ import {AutocorrectService} from "../services/autocorrect.service";
 import { SpeechSynthesisService } from "../services/speech-synthesis.service";
 import {InfiniteScrollModule} from "ngx-infinite-scroll";
 import {ChartsModule} from "ng2-charts";
+import {InfoboxComponent} from "../infobox/infobox.component";
+import {KnowledgeapiService} from "../services/knowledgeapi.service";
 
 describe('ResultsComponent', () => {
   let component: ResultsComponent;
@@ -74,7 +76,8 @@ describe('ResultsComponent', () => {
         IntelligenceComponent,
         SpeechtotextComponent,
         AutoCorrectComponent,
-        StatsboxComponent
+        StatsboxComponent,
+        InfoboxComponent
       ],
       providers: [
         SearchService,
@@ -83,7 +86,8 @@ describe('ResultsComponent', () => {
         SpeechService,
         IntelligenceService,
         AutocorrectService,
-        SpeechSynthesisService
+        SpeechSynthesisService,
+        KnowledgeapiService
       ]
     })
       .compileComponents();
@@ -122,6 +126,12 @@ describe('ResultsComponent', () => {
 
     expect(compiled.querySelector('app-theme')).toBeTruthy();
   });
+
+  it('should have an app-infobox element', () => {
+        let compiled = fixture.debugElement.nativeElement;
+
+        expect(compiled.querySelector('app-infobox')).toBeTruthy();
+      });
 
 
   it('should have a search options menu', () => {

--- a/src/app/search-bar/search-bar.component.spec.ts
+++ b/src/app/search-bar/search-bar.component.spec.ts
@@ -10,6 +10,7 @@ import { AutocompleteService } from "../services/autocomplete.service";
 import { AutoCompleteComponent } from "../auto-complete/auto-complete.component";
 import { SpeechService } from '../services/speech.service';
 import { ThemeService } from '../services/theme.service';
+import {InfoboxComponent} from "../infobox/infobox.component";
 
 describe('Component: SearchBarComponent', () => {
   let component: SearchBarComponent;
@@ -27,6 +28,7 @@ describe('Component: SearchBarComponent', () => {
       declarations: [
         SearchBarComponent,
         AutoCompleteComponent,
+        InfoboxComponent
       ],
       providers: [
         AutocompleteService,

--- a/src/app/services/knowledgeapi.service.spec.ts
+++ b/src/app/services/knowledgeapi.service.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { KnowledgeapiService } from './knowledgeapi.service';
+import {HttpModule, JsonpModule} from "@angular/http";
+import {reducer} from "../reducers/index";
+import {StoreModule} from "@ngrx/store";
+import {StoreDevtoolsModule} from "@ngrx/store-devtools";
+
+describe('KnowledgeapiService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule,
+        JsonpModule,
+        StoreModule.provideStore(reducer),
+        StoreDevtoolsModule.instrumentOnlyWithExtension(),
+      ],
+      providers: [KnowledgeapiService]
+    });
+  });
+
+  it('should ...', inject([KnowledgeapiService], (service: KnowledgeapiService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/knowledgeapi.service.ts
+++ b/src/app/services/knowledgeapi.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import {Http, URLSearchParams, Jsonp, Response, Headers, RequestOptions} from '@angular/http';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/toPromise';
+import {Store} from '@ngrx/store';
+import * as fromRoot from '../reducers';
+import * as search from '../actions/search';
+import {Observable} from 'rxjs';
+
+@Injectable()
+export class KnowledgeapiService {
+
+  server = 'https://en.wikipedia.org';
+  searchURL = this.server + '/w/api.php?';
+  homepage = 'http://susper.com';
+  logo = '../images/susper.svg';
+  constructor(private http: Http,
+              private jsonp: Jsonp,
+              private store: Store<fromRoot.State>) {
+  }
+  getsearchresults(searchquery) {
+
+    let params = new URLSearchParams();
+
+    params.set('origin', '*');
+    params.set('format', 'json');
+    params.set('action', 'query');
+    params.set('prop', 'extracts');
+    params.set('exintro', '');
+    params.set('explaintext', '');
+    params.set('titles', searchquery);
+
+    let headers = new Headers({ 'Accept': 'application/json' });
+    let options = new RequestOptions({ headers: headers, search: params });
+    return this.http
+      .get(this.searchURL, options).map(res =>
+          res.json().query.pages
+      ).catch(this.handleError);
+
+  }
+  private handleError (error: any) {
+    // In some advance version we can include a remote logging of errors
+    const errMsg = (error.message) ? error.message :
+      error.status ? `${error.status} - ${error.statusText}` : 'Server error';
+    console.error(errMsg); // Right now we are logging to console itself
+    return Observable.throw(errMsg);
+  }
+}

--- a/src/app/terms/terms.component.spec.ts
+++ b/src/app/terms/terms.component.spec.ts
@@ -9,6 +9,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule } from '@angular/forms';
 import { FooterNavbarComponent } from '../footer-navbar/footer-navbar.component';
 import { TermsComponent } from './terms.component';
+import {InfoboxComponent} from "../infobox/infobox.component";
 
 describe('Component: Terms', () => {
   let component: TermsComponent;
@@ -22,7 +23,8 @@ describe('Component: Terms', () => {
       ],
       declarations: [
         FooterNavbarComponent,
-        TermsComponent
+        TermsComponent,
+        InfoboxComponent
       ]
     })
     .compileComponents();


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #797 #181 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
- I have replaced DBpedia API with Wikipedia API to implement Infobox in SUSPER . 
- Earlier requests of DBpedia API was getting blocked but for Wikipedia API it will not be blocked and we will get an infobox on susper.com.

- Our next aim will be to add images for search query and tests for this feature, this can be done by going through Wikipedia API more deeply.
Surge Link: https://pr-1011-fossasia-susper.surge.sh
<!-- Screenshots for the change: Add here the screenshot of the fix. -->

![image](https://user-images.githubusercontent.com/25537606/40869752-96e57422-663d-11e8-8f32-40f58cb91b1c.png)


