### PR TITLE
Fixed the links of results from News Tab

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -168,7 +168,7 @@
     <div class="feed container">
       <div *ngFor="let item of items$|async" class="result">
         <div class="title">
-          <a class="title-pointer" href="{{item.path}}">{{item.title}}</a>
+          <a class="title-pointer" href="{{item.link}}">{{item.title}}</a>
         </div>
         <div class="link">
           <p>{{item.link}}</p>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1033 News Tab Link problem

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Changed the href of the results from News Tab so when clicking on  a link from News Tab, it will redirect the user to the correct link.

<!-- Demo Link: Add here the link where you changes can be seen. -->

- Surge link: https://pr-1034-fossasia-susper.surge.sh

<!-- Screenshots for the change: Add here the screenshot of the fix. -->

#### Screenshot:

![result_new](https://user-images.githubusercontent.com/33882273/41552412-588db69c-7337-11e8-87e0-adb533bd9a11.jpg)

