### PR TITLE
Fixes #1000: Different result sections can be opened in New Tab

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -4,9 +4,12 @@
   <div class="row" [style.background-color]="themeService.backgroundColor">
     <div class="container-fluid" id="search-options-field" [style.background-color]="themeService.navbarbgColor">
       <ul type="none" id="search-options">
-        <li [class.active_view]="Display('all')" (click)="docClick()">All</li>
-        <li [class.active_view]="Display('images')" (click)="imageClick()">Images</li>
-        <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
+        <a href='/search?query={{this.searchdata.query}}&start={{this.searchdata.start}}&rows={{this.searchdata.rows}}&mode=text' *ngIf="!Display('all')"><li [class.active_view]="Display('all')" (click)="docClick()">All</li></a>
+        <li [class.active_view]="Display('all')" (click)="docClick()" *ngIf="Display('all')">All</li>
+        <a href='/search?query={{this.searchdata.query}}&start={{this.searchdata.start}}&rows={{this.searchdata.rows}}&fq=url_file_ext_s%3A(png%2BOR%2Bjpeg%2BOR%2Bjpg%2BOR%2Bgif)&mode=text' *ngIf="!Display('images')"><li [class.active_view]="Display('images')" (click)="imageClick()">Images</li></a>
+        <li [class.active_view]="Display('images')" (click)="imageClick()" *ngIf="Display('images')">Images</li>
+        <a href='/search?query={{this.searchdata.query}}&start={{this.searchdata.start}}&rows={{this.searchdata.rows}}&mode=text&nopagechange=false&append=false&fq=url_file_ext_s%3A(avi%2BOR%2Bmov%2BOR%2Bflw%2BOR%2Bmp4)&resultDisplay=videos' *ngIf="!Display('videos')"><li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li></a>
+        <li [class.active_view]="Display('videos')" (click)="videoClick()" *ngIf="Display('videos')">Videos</li>
         <li [class.active_view]="Display('news')" (click)="newsClick()">News</li>
         <li class="dropdown">
           <a href="#" id="settings" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1000

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
Different result sections can be opened in New Tab.
Note: There were some issues implementing this feature with News Tab. It is the problem with News Tab that it modifies the current query. I am working to fix that issue and I will expand this feature to news tab once that is fixed. So this will not work for News Tab. 

Surge Link: https://pr-1043-fossasia-susper.surge.sh