### PR TITLE
Fixes #1054: Restored Video tab

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -8,8 +8,7 @@
         <li [class.active_view]="Display('all')" (click)="docClick()" *ngIf="Display('all')">All</li>
         <a href='/search?query={{this.searchdata.query}}&start={{this.searchdata.start}}&rows={{this.searchdata.rows}}&fq=url_file_ext_s%3A(png%2BOR%2Bjpeg%2BOR%2Bjpg%2BOR%2Bgif)&mode=text' *ngIf="!Display('images')"><li [class.active_view]="Display('images')" (click)="imageClick()">Images</li></a>
         <li [class.active_view]="Display('images')" (click)="imageClick()" *ngIf="Display('images')">Images</li>
-        <a href='/search?query={{this.searchdata.query}}&start={{this.searchdata.start}}&rows={{this.searchdata.rows}}&mode=text&nopagechange=false&append=false&fq=url_file_ext_s%3A(avi%2BOR%2Bmov%2BOR%2Bflw%2BOR%2Bmp4)&resultDisplay=videos' *ngIf="!Display('videos')"><li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li></a>
-        <li [class.active_view]="Display('videos')" (click)="videoClick()" *ngIf="Display('videos')">Videos</li>
+        <li [class.active_view]="Display('videos')" (click)="videoClick()">Videos</li>
         <li [class.active_view]="Display('news')" (click)="newsClick()">News</li>
         <li class="dropdown">
           <a href="#" id="settings" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1054 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
I implemented different result section in links to allow user to open it New Tab but due to this video search was not working so I have restored it as earlier. There is one more issue, Currently when we click on any tab i.e All, Images or Videos the website flickers little bit it is also occurring due to conversion of tabs in link. Flickering occurs even on Google.com but on Google it occurs more fastly and can be noticed only while paying more attention while clicking other tabs(The whole page loads very fastly from Google servers). I am keeping `All` and `Images` tab as it is now and will discuss about it with Mario.
Thank You 
Surge Link: https://pr-1055-fossasia-susper.surge.sh