### PR TITLE
Fixes #1059: All images now are within infobox

### DIFF
--- a/src/app/infobox/infobox.component.css
+++ b/src/app/infobox/infobox.component.css
@@ -14,11 +14,7 @@ img{
   padding: 22px 22px 18px 22px;
   transition: 0.3s;
   width: 454px;
-}
-
-/* Add some padding inside the card container */
-.card-container {
-  padding: 2px 16px;
+  min-height: 200px;
 }
 
 /* Heading */

--- a/src/app/infobox/infobox.component.html
+++ b/src/app/infobox/infobox.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="this.description" class="card">
+<div *ngIf="this.description" class="card" [style.color]="themeService.cardColor">
     <div>
       <h2><b [style.color]="themeService.cardColor">{{this.title}}</b></h2><img *ngIf="this.image"  src={{this.image}}>
       <p [style.color]="themeService.descriptionColor">{{this.description | slice:0:600}}<a [style.color]="themeService.linkColor" href='https://en.wikipedia.org/wiki/{{this.title}}'>..More at Wikipedia</a></p>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1059 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
For some queries say `uno` still the images were overlapping in infobox. It was happening because for these query the infobox becomes very small in size. I have fixed infobox to a minimum size.
Surge Link: https://pr-1076-fossasia-susper.surge.sh