### PR TITLE
Fixes #1060: Hide infobox if no results are present from a query

### DIFF
--- a/src/app/infobox/infobox.component.html
+++ b/src/app/infobox/infobox.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="this.description" class="card" [style.color]="themeService.cardColor">
+<div *ngIf="this.description" class="card" [hidden]="!isVisible" [style.color]="themeService.cardColor">
     <div>
       <h2><b [style.color]="themeService.cardColor">{{this.title}}</b></h2><img *ngIf="this.image"  src={{this.image}}>
       <p [style.color]="themeService.descriptionColor">{{this.description | slice:0:600}}<a [style.color]="themeService.linkColor" href='https://en.wikipedia.org/wiki/{{this.title}}'>..More at Wikipedia</a></p>

--- a/src/app/infobox/infobox.component.ts
+++ b/src/app/infobox/infobox.component.ts
@@ -15,6 +15,7 @@ export class InfoboxComponent implements OnInit {
   results: object;
   query$: any;
   image: string;
+  isVisible: boolean;
   resultsearch = '/search';
   speechMode: any;
   content_response$: Observable<any>;
@@ -24,10 +25,12 @@ export class InfoboxComponent implements OnInit {
     this.query$ = store.select(fromRoot.getquery);
     this.content_response$ = store.select(fromRoot.getKnowledgeContent);
     this.content_response$.subscribe(res => {
+    this.isVisible = false;
     this.results = res;
       if (res.extract) {
         this.title = res.title;
         this.description = res.extract;
+        this.isVisible = true;
       }
     });
     this.image_response$ = store.select(fromRoot.getKnowledgeImage);
@@ -42,5 +45,4 @@ export class InfoboxComponent implements OnInit {
 
   ngOnInit() {
   }
-
 }


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1060 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
The results in infobox were not displayed properly when several searches were performed because for any query if no results were retrieved from Wikipedia API then results related to previous query was shown. I have hidden the whole infobox if no results are retrieved from Wikipedia API.
Surge Link: https://pr-1079-fossasia-susper.surge.sh