### PR TITLE
Fixes #1162: Reverted color of `More at Wikipedia` text

### DIFF
--- a/src/app/infobox/infobox.component.css
+++ b/src/app/infobox/infobox.component.css
@@ -35,9 +35,8 @@ p {
 }
 a:hover, a:visited, a:link, a:active {
   text-decoration: none;
-  color: #006621;
 }
-.query_description{
+.query_description {
   color: #777;
   font-family: arial,sans-serif;
   margin-top: -25px;


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1162 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Reverted color of `More at Wikipedia` text

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1164-fossasia-susper.surge.sh
- Please clear your cache before reviewing.