### PR TITLE
Fixing About page css

### DIFF
--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -44,6 +44,11 @@ dl {
   width:96%;
 }
 
+.text-center {
+  padding-top:20px;
+  font-size:30px !important;
+}
+
 body, table, textarea {
   font-size: 12px;
   overflow-x: hidden;


### PR DESCRIPTION

Fixes #1297 

#### Changes proposed in this pull request:

adding css for the .text-centre clases
bootstrap.min.css file tags are under-weighted that's why they are not working 
and it also do not contain the padding tag which lead to NO gap or padding between image and the text 
<!-- Screenshots for the change: Add here the screenshot of the fix. -->
![screenshot from 2018-12-14 17-29-23](https://user-images.githubusercontent.com/34541684/50002713-0018cc00-ffc7-11e8-944d-230d5e7d4a41.png)

