### PR TITLE
Fixing the wrong directed susper logo link

### DIFF
--- a/src/app/index/index.component.html
+++ b/src/app/index/index.component.html
@@ -4,7 +4,7 @@
       <div id="search-bar">
         <div class="row">
           <div id="susper-logo-fix">
-            <a href="https://{{fossasia_repo}}/susper.com"><img src="assets/images/susper.svg" alt="Susper" id="biglogo"></a>
+            <a href="https://susper.com"><img src="assets/images/susper.svg" alt="Susper" id="biglogo"></a>
           </div>
         </div>
         <h2 class="yacy" id="greeting"></h2>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1329 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- changing the value of href attribute

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1330-fossasia-susper.surge.sh


