### PR TITLE
Analytics border lie inside the window

### DIFF
--- a/src/app/statsbox/statsbox.component.css
+++ b/src/app/statsbox/statsbox.component.css
@@ -196,7 +196,7 @@ a {
 
 @media screen and (max-width: 767px){
   .card {
-    width: 95vw;
+    width: 90vw;
     margin-left: 4vw;
   }
 }


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1345

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
Analytics border lies inside the window when the screen size is reduced.

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1346-fossasia-susper.surge.sh

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
![border](https://user-images.githubusercontent.com/32234926/50431615-32dd9100-08f2-11e9-90b0-f7e8cc8e8812.PNG)
