### PR TITLE
Depth field in Crawl Job page only accepts numbers

### DIFF
--- a/src/app/crawlstart/crawlstart.component.html
+++ b/src/app/crawlstart/crawlstart.component.html
@@ -112,7 +112,7 @@
             <div class="col-md-4"><label for="last update">Maximum Pages per Domain</label></div>
             <div class="col-md-6">
               <input type="checkbox" name="DomMaxCheck" [(ngModel)]="crawlvalues.crawlingDomMaxCheck"><span>Use Page Count:</span>
-              <input type="text" class="form-control" id="last update" name="DomMaxPages" [(ngModel)]="crawlvalues.crawlingDomMaxPages" size="6" maxlength="6">
+              <input type="number" class="form-control" id="last update" name="DomMaxPages" [(ngModel)]="crawlvalues.crawlingDomMaxPages" size="6" maxlength="6">
             </div>
           </div>
 
@@ -306,7 +306,7 @@
           <div class="form-group">
             <div class="col-md-4"><label>Max Depth for Snapshots</label></div>
             <div class="col-md-6">
-              <input type="text" name="snapshotsmaxdepth" class="form-control" [(ngModel)]="crawlvalues.snapshotsMaxDepth" size="2" maxlength="2" value="-1">
+              <input type="number" name="snapshotsmaxdepth" class="form-control" [(ngModel)]="crawlvalues.snapshotsMaxDepth" size="2" maxlength="2" value="-1">
             </div>
           </div>
 


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1366 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
Fields that take ask for depth of search results, now take only number inputs which was earlier text.

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1381-fossasia-susper.surge.sh

