### PR TITLE
Fix #1388 : "did you mean" content is now clickable

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -153,9 +153,6 @@
             or change this list, please check <a href="{{ newsFileUrl }}">here</a>
           </div>
         </div>
-        <div class="autocorrect">
-          <app-auto-correct [hidden]="hideAutoCorrect"></app-auto-correct>
-        </div>
       </div>
 
       <div class="text-result" *ngIf="Display('all')">
@@ -173,6 +170,9 @@
           </div>
         </div>
         <div class="container-fluid">
+          <div class="autocorrect">
+            <app-auto-correct [hidden]="hideAutoCorrect"></app-auto-correct>
+          </div>
           <div class="combo-box">
             <div class="small-info"><app-infobox></app-infobox></div>
           </div>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Moved the suggestion HTML code to the same component with feed part.

<!-- Demo Link: Add here the link where you changes can be seen. -->

- Surge link: https://pr-1411-fossasia-susper.surge.sh

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
#### Screenshot
![screenshot from 2019-01-15 11-32-26](https://user-images.githubusercontent.com/33882273/51171346-583e3900-18b9-11e9-81eb-9e6f277cc9ef.png)

