### PR TITLE
Fixing Result numbers not displayed ( for images section )

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -142,7 +142,7 @@
         <div
           id="result-message"
           class="result message-bar"
-          *ngIf="totalNumber > 0 && !Display('images') && !Display('news')"
+          *ngIf="totalNumber > 0 && !Display('news')"
         >
           {{ message }}
         </div>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1136 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Adding div container for adding total results for images section 

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1422-fossasia-susper.surge.sh

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
- 
![screenshot_2019-01-23 susper - decentral search engine](https://user-images.githubusercontent.com/34541684/51558661-06437780-1ea6-11e9-81f2-9bae5f3a4173.png)

