### PR TITLE
Number input fields only accept number inputs

### DIFF
--- a/src/app/newadvancedsearch/newadvancedsearch.component.html
+++ b/src/app/newadvancedsearch/newadvancedsearch.component.html
@@ -54,13 +54,13 @@
 
         <div class="form-group">
           <div class="col-md-4"><label class="label-search" for="number">numbers ranging from:</label></div>
-          <div class="col-md-2"><input type="text" class="form-control" id="number"></div>
+          <div class="col-md-2"><input type="number" class="form-control" id="number"></div>
 
           <div class="col-md-2" style="text-align: center">
             <label for="to" class="to-word-alignment">to</label>
           </div>
 
-          <div class="col-md-2"><input type="text" class="form-control" id="to"></div>
+          <div class="col-md-2"><input type="number" class="form-control" id="to"></div>
         </div>
 
       </div>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1355 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
The type of input fields (`numbers ranging from`) in Advanced Search that can only accept numbers is changed to `number`, so that they accept only number input.
 
<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1437-fossasia-susper.surge.sh

