### PR TITLE
Number input field accepts only numbers

### DIFF
--- a/src/app/newadvancedsearch/newadvancedsearch.component.html
+++ b/src/app/newadvancedsearch/newadvancedsearch.component.html
@@ -71,13 +71,13 @@
 
     <div class="form-group row">
       <div class="col-md-2"><label class="label-search" for="number">numbers ranging from:</label></div>
-      <div class="col-md-2"><input type="text" class="form-control" id="number"></div>
+      <div class="col-md-2"><input type="number" class="form-control" id="number"></div>
 
       <div class="col-md-1" style="height:34px; line-height:34px; text-align: center;">
         <label for="to" class="word-alignment" style="font-size: 12px !important; color: black !important;">to</label>
       </div>
 
-      <div class="col-md-2"><input type="text" class="form-control" id="to"></div>
+      <div class="col-md-2"><input type="number" class="form-control" id="to"></div>
       <div class="col-md-5" id="help-labels">
         <span class="word-alignment">
           Put two full stops between the numbers and add a unit of measurement: 10..35 kg, £300..£500, 2010..2011


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1355 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:
The type of input fields (`numbers ranging from`) in Advanced Search that can only accept numbers is changed to `number`, so that they accept only number input.
 
<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1438-fossasia-susper.surge.sh



