### PR TITLE
Fixing Search Setting ( search result tab ) ( base tag problem)

### DIFF
--- a/src/app/searchsettings/searchsettings.component.html
+++ b/src/app/searchsettings/searchsettings.component.html
@@ -32,7 +32,7 @@
 
     <div class="leftPane col-md-2">
         <ul class="left-list">
-          <li ><a class="active" href="#">Search Results</a></li>
+          <li ><a class="active" routerLink="/preferences">Search Results</a></li>
           <li><a href="#">Languages</a></li>
           <li><a routerLink="/help">Help</a></li>
         </ul>


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #1301 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Because of Base tag ( for relative URLs ) is directing search setting tab to index page . 
using routerlink will fix it

<!-- Demo Link: Add here the link where you changes can be seen. -->

- https://pr-1441-fossasia-susper.surge.sh

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
