### PR TITLE
Add stale bot workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: "Stale issue handler"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@main
+        id: stale
+        with:
+          stale-issue-label: "stale"
+          stale-issue-message: 'This issue has been automatically marked as stale because it has been open for 14 days without activity. It will be closed if no further activity occurs within the next 14 days. If this is still an issue, just leave a comment or remove the "stale" label.'
+          days-before-stale: 14
+          days-before-close: 14
+          operations-per-run: 1000
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: 'type: bug, type: docs, type: feature, type: improvement, type: question' # All 'type: ' labels
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
So, I have noticed there is a plenty of abandoned issues for this project, the purpose of this bot is to automatically stale GitHub issues after 14days of inactivity

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)
- [x] Added Surge preview link
<!-- Replace "PR_NUMBER" with your pull request number. This link is generated when your PR passes the travis tests.A sample link can look like https://pr-200-fossasia-susper.surge.sh -->

Not available with surge nor any preview links because CI stuff, but here some proof: https://prnt.sc/3LiHOY_BxJjW
